### PR TITLE
When loading known permalink sessions, force isPermalinkSession to true.

### DIFF
--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -1452,6 +1452,11 @@ exports.UnhangoutServer.prototype = {
 
 			"session/permalink/*":_.bind(function(callback, attrs, key) {
 				var newSession = new models.ServerSession(attrs);
+
+				// force these to be true. This fixes a transient condition where some
+				// keys in the db didn't have this set and it defaults to false.
+				newSession.set("isPermalinkSession", true);
+
 				this.permalinkSessions.add(newSession);
 				callback();
 			}, this)


### PR DESCRIPTION
Fixes #160.
