### PR TITLE
Fixes to installation docs; remove unused "login"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib-cov
 *.gz
 *.iml
 *.rdb
+*.swp
 
 pids
 logs
@@ -21,6 +22,8 @@ node_modules
 
 # ignore conf.json, so we can safely keep settings in there.
 conf.json
+# ignore ssl, to ensure we never check certs in.
+ssl/
 
 .sass-cache
 .idea

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -51,17 +51,22 @@ C. Cloning the Repository.
     $ cd unhangout
     
   - Create a file and copy the contents of conf.json.example file in it. Name this file conf.json. 
-    conf.json.example file contains environment variables to specify server settings. GOOGLE_CLIENT_ID &
-    GOOGLE_CLIENT_SECRET fields are app credentials that can be configured and obtained at 
-    http://code.google.com/apis/console/
-
-    In the Google API console, you should make a "Client ID for web applications" - that will create
-    the necessary CLIENT_ID and CLIENT_SECRET you need to authenticate with Google and create
-    calendar events.
+    conf.json.example file contains environment variables to specify server settings.
 
     $ touch conf.json <br>
     $ gedit conf.json [copy contents from conf.json.example here]
     
+    GOOGLE_CLIENT_ID & GOOGLE_CLIENT_SECRET fields are app credentials that can
+    be configured and obtained at http://code.google.com/apis/console/.
+    In the Google API console, you should make a "Client ID for web applications" - that will create
+    the necessary CLIENT_ID and CLIENT_SECRET you need to authenticate with Google and create
+    calendar events.  Set the callback URL to https://localhost:7777/auth/google/callback
+    (swap out the hostname and port with whichever settings you use).
+
+    UNHANGOUT_ADMIN_EMAILS is a list of email addresses which are granted
+    "admin" status when they authenticate.  (The server must be restarted and
+    clients must re-login to change their admin status).
+
   - Install data structure redis server <br>
     $ sudo apt-get install redis-server 
     

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -98,7 +98,7 @@ if(require.main === module)
 			{
 				timestamp: true
 			})
-			],
+			]
 		});
 		
 	logger.cli();
@@ -121,6 +121,6 @@ if(require.main === module)
 				filename: "seed.log",
 				timestamp: true
 			})
-			],
+			]
 		});
 }

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -759,10 +759,6 @@ exports.UnhangoutServer.prototype = {
 			res.render('event.ejs', context);
 		}, this));
 		
-		this.express.get('/login', function(req, res) {
-			res.render('login', {user:req.user});
-		});
-		
 		// the passport middleware (passport.authenticate) should route this request to
 		// google, and not call the rendering callback below.
 		this.express.get("/auth/google", passport.authenticate('google', { scope: ['https://www.googleapis.com/auth/userinfo.profile',
@@ -774,7 +770,7 @@ exports.UnhangoutServer.prototype = {
 		
 		// after a user authenticates at google, google will redirect them to this url with
 		// an authentication token that is consumed by passport.authenticate. 
-		this.express.get("/auth/google/callback", passport.authenticate('google', {failureRedirect: '/login'}),
+		this.express.get("/auth/google/callback", passport.authenticate('google'),
 			function(req, res) {
 
 				// if post-auth-path was set, send them to that path now that authentication


### PR DESCRIPTION
Add a notes to INSTALLATION.md explaining:
- What to set the callback URL
- how "UNHANGOUT_ADMIN_EMAILS" works

Also remove unused "login" route and method from
lib/unhangout-server.js.  Passport doesn't seem to use "failureRedirect"
when it has an explicit handler method set -- but even if it did, the
login route was calling an undefined view.  Currently, an auth failure
from "google" results in a 500 with error message, which is acceptable,
as the only thing that should cause auth failures is misconfiguration of
UNHANGOUT_GOOGLE_CLIENT_ID or UNHANGOUT_GOOGLE_SESSION_SECRET.
