### PR TITLE
Split "/about/" out; deduplicate template context

### DIFF
--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -228,6 +228,11 @@ exports.UnhangoutServer.prototype = {
 		logger.log("info", "Starting UnhangoutServer on %s:%d", this.options.HOST, this.options.PORT);
 		
 		this.express = express();
+        this.express.locals = {
+            _: _,
+            event: undefined,
+            user: undefined
+        }
 
 		if(this.options.USE_SSL) {
 			try {
@@ -699,11 +704,15 @@ exports.UnhangoutServer.prototype = {
 		
 		// routing for the homepage
 		this.express.get("/", _.bind(function(req, res) {
-			res.render('index.ejs', {user:req.user, events:this.events, event:undefined, _:_, loadApp:false});
+			res.render('index.ejs', {user: req.user});
+		}, this));
+
+		this.express.get("/about/", _.bind(function(req, res) {
+			res.render('index.ejs', {user: req.user});
 		}, this));
 
 		this.express.get("/how-to-unhangout/", _.bind(function(req, res) {
-			res.render('how-to-unhangout.ejs', {user:req.user, events: this.events, event:undefined, _:_, loadApp:false});
+			res.render('how-to-unhangout.ejs', {user: req.user});
 		}, this));
 		
 		// routing for events
@@ -751,7 +760,7 @@ exports.UnhangoutServer.prototype = {
 				return;
 			}
 
-			var context = {user:req.user, event:e, _:_, loadApp:true};
+			var context = {user:req.user, event:e};
 			if(!_.isUndefined(farming)) {
 				context["numFarmedHangouts"] = farming.getNumHangoutsAvailable();
 			}
@@ -876,7 +885,7 @@ exports.UnhangoutServer.prototype = {
 		//---------------------------------------------------------//
 
 		this.express.get("/h/", _.bind(function(req, res) {
-			res.render('permalink-intro.ejs', {user:undefined, event:undefined, _:_, loadApp:false});
+			res.render('permalink-intro.ejs');
 		}, this));
 
 		this.express.get("/h/admin/:code/:key", _.bind(function(req, res) {
@@ -893,7 +902,7 @@ exports.UnhangoutServer.prototype = {
 
 			if(req.params.key===session.get("creationKey")) {
 				// now render the normal permalink view, but with the admin interface showing.
-				res.render('permalink.ejs', {showAdmin: true, user:undefined, users:this.users, session:session, event:undefined, _:_, loadApp:false});
+				res.render('permalink.ejs', {showAdmin: true, users:this.users, session:session });
 			} else {
 				logger.warn("Attempt to load /h/admin/:code/:key with invalid key for this session: " + req.params.key);
 				res.status(403);
@@ -950,7 +959,7 @@ exports.UnhangoutServer.prototype = {
 			// going to have to have the participant information sent from the
 			// hangout app instead of just the ids involved.
 
-			res.render('permalink.ejs', {showAdmin: false, user:undefined, users:this.users, session:session, event:undefined, _:_, loadApp:false});
+			res.render('permalink.ejs', {showAdmin: false, users:this.users, session:session});
 
 			// after rendering, drop the first-load 
 			if(session.get("first-load")) {
@@ -1225,14 +1234,14 @@ exports.UnhangoutServer.prototype = {
 
 			var allSessions = sessions.concat(sortedPermalinkSesssions);
 
-			res.render('admin.ejs', {user:req.user, events:this.events, sessions:allSessions, event:undefined, _:_, loadApp:false});
+			res.render('admin.ejs', {user:req.user, events:this.events, sessions:allSessions, event:undefined });
 		}, this));
 
 		this.express.get("/admin/event/new", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
 			logger.debug("GET /admin/event/new");
 			var event = this.events.get(req.params.id);
 
-			var context = {user:req.user, events:this.events, event:event, _:_, loadApp:false, create:true};
+			var context = {user:req.user, events:this.events, event:event, create:true};
 
 			res.render('admin-event.ejs', context);
 		}, this));

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2,17 +2,13 @@
 
 $(document).on('ready', function() {
 
-	$("#about").hide();
-	$(".nav li").click(function() {
-		$(".active").removeClass("active");
-
-		var aEl = $(this).find("a");
-
-		$(this).addClass("active");
-
-		$(".section").hide();
-		$(aEl.attr("href")).show();
-	});
+    $(".nav li").each(function(i, el) {
+        if ($(el).find("a").attr("href") == window.location.pathname) {
+            $(el).addClass("active");
+        } else {
+            $(el).removeClass("active");
+        }
+    });
 
 	$("#subscribe").click(function() {
 		var email = $("#email").val();

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -1,0 +1,84 @@
+<% include header.ejs %>
+        <div class="section" id="about">
+            <h1>About</h1>
+
+            <p><strong>Unhangout</strong> is an open source
+            platform for running large scale online un-conferences.
+            We use Google Hangouts to create as many small sessions
+            as needed, and help users find others with shared
+            interests.</p>
+
+            <div class="modal hide fade disconnected-modal" id=
+            "disconnected-modal">
+                <div class="modal-header">
+                    <h3>Warning!</h3>
+                </div>
+
+                <div class="modal-body">
+                    <p>An unexpected error has occured. You have
+                    been disconnected from the server. Please
+                    refresh the page to reconnect.</p><a class=
+                    "btn" href="#">Close</a>
+                </div>
+            </div>
+
+            Think of it as a classroom with an infinite
+            number of breakout sessions. Each event has a landing
+            page, which we call the lobby. When participants
+            arrive, they can see who else is there and chat with
+            each other. The hosts can do a video welcome and
+            introduction that gets streamed into the lobby.
+            Participants then break out into smaller sessions (up
+            to 10 people per session) for in-depth conversations,
+            peer-to-peer learning, and collaboration on projects.
+            UnHangouts are community-based learning instead of
+            top-down information transfer.
+            <p>
+
+            <h3>Open Source</h3>
+
+            <p><strong>Unhangout</strong> is an open source
+            project. You can find the code in <a href=
+            "https://github.com/drewww/unhangout">our repository on
+            GitHub</a>. Please let us know if you're interested in
+            hosting your own unhangout events - we would be happy
+            to help you get this set up on your own servers. In
+            some situations, we might be able to host your event on
+            our installation, too.</p>
+
+            <p></p>
+
+            <h3>The Team</h3>
+
+            <p>Our three person design and development team is
+            based at the MIT Media Lab in Cambridge, MA.</p>
+
+            <ul>
+                <li>
+                    <a href=
+                    "http://www.media.mit.edu/people/ps1">Philipp
+                    Schmidt</a>
+                </li>
+
+                <li>
+                    <a href="http://web.media.mit.edu/~dharry">Drew
+                    Harry</a>
+                </li>
+
+                <li>
+                    <a href="http://srishtisethi.com/">Srishti
+                    Sethi</a>
+                </li>
+            </ul>
+
+            <h3>Acknowledgements</h3>
+
+            <p><strong>Unhangout</strong> is made possible by the
+            generous support of the MacArthur Foundation and the
+            MIT Media Lab</p>
+        </div>
+
+<% include sponsorship.ejs %>
+<% include analytics.ejs %>
+<% include footer.ejs %>
+            

--- a/views/analytics.ejs
+++ b/views/analytics.ejs
@@ -1,0 +1,9 @@
+    <script>
+  	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  	ga('create', 'UA-42792478-1', 'mit.edu');
+  	ga('send', 'pageview');
+    </script>

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -13,16 +13,7 @@
 	    <link href="/public/css/ie.css" media="screen, projection" rel="stylesheet" type="text/css" />
 	<![endif]-->
 
-	<script>
-  	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  	ga('create', 'UA-42792478-1', 'mit.edu');
-  	ga('send', 'pageview');
-
-	</script>
+    <% include analytics.ejs %>
 	
 	<script type="text/javascript" src="//code.jquery.com/jquery-2.0.0.js"></script>
 	<script type="text/javascript" src="/public/js/jquery-ui-1.10.3.custom.min.js"></script>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -46,8 +46,8 @@
 				</button>
 				<div class="nav-collapse collapse">
 					<ul class="nav">
-						<li class="active"><a href="#home">Home</a></li>
-						<li><a href="#about">About</a></li>
+						<li class="active"><a href="/">Home</a></li>
+						<li><a href="/about/">About</a></li>
 						<li><a href="/how-to-unhangout/">How to Unhangout</a></li>
 						<% if(user && user.isAdmin()) { %>
 							<li id="admin-nav"><a href="/admin/">Admin</a></li>

--- a/views/how-to-unhangout.ejs
+++ b/views/how-to-unhangout.ejs
@@ -115,6 +115,6 @@
 
 </div>
 
-<div class="footer">An MIT Media Lab project, in collaboration with the MacArthur Foundation.</div>
-
+<% include sponsorship.ejs %>
+<% include analytics.ejs %>
 <% include footer.ejs %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,17 +1,5 @@
 <% include header.ejs %>
 
-<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-42792478-1', 'mit.edu');
-ga('send', 'pageview');
-
-</script>
-
-
 <div class="jumbotron">
     <h1>The Unhangout Project</h1>
 
@@ -207,88 +195,6 @@ ga('send', 'pageview');
             </div>
         </div>
 
-        <div class="section" id="about">
-            <h1>About</h1>
-
-            <p><strong>Unhangout</strong> is an open source
-            platform for running large scale online un-conferences.
-            We use Google Hangouts to create as many small sessions
-            as needed, and help users find others with shared
-            interests.</p>
-
-            <div class="modal hide fade disconnected-modal" id=
-            "disconnected-modal">
-                <div class="modal-header">
-                    <h3>Warning!</h3>
-                </div>
-
-                <div class="modal-body">
-                    <p>An unexpected error has occured. You have
-                    been disconnected from the server. Please
-                    refresh the page to reconnect.</p><a class=
-                    "btn" href="#">Close</a>
-                </div>
-            </div>
-
-            Think of it as a classroom with an infinite
-            number of breakout sessions. Each event has a landing
-            page, which we call the lobby. When participants
-            arrive, they can see who else is there and chat with
-            each other. The hosts can do a video welcome and
-            introduction that gets streamed into the lobby.
-            Participants then break out into smaller sessions (up
-            to 10 people per session) for in-depth conversations,
-            peer-to-peer learning, and collaboration on projects.
-            UnHangouts are community-based learning instead of
-            top-down information transfer.
-            <p>
-
-            <h3>Open Source</h3>
-
-            <p><strong>Unhangout</strong> is an open source
-            project. You can find the code in <a href=
-            "https://github.com/drewww/unhangout">our repository on
-            GitHub</a>. Please let us know if you're interested in
-            hosting your own unhangout events - we would be happy
-            to help you get this set up on your own servers. In
-            some situations, we might be able to host your event on
-            our installation, too.</p>
-
-            <p></p>
-
-            <h3>The Team</h3>
-
-            <p>Our three person design and development team is
-            based at the MIT Media Lab in Cambridge, MA.</p>
-
-            <ul>
-                <li>
-                    <a href=
-                    "http://www.media.mit.edu/people/ps1">Philipp
-                    Schmidt</a>
-                </li>
-
-                <li>
-                    <a href="http://web.media.mit.edu/~dharry">Drew
-                    Harry</a>
-                </li>
-
-                <li>
-                    <a href="http://srishtisethi.com/">Srishti
-                    Sethi</a>
-                </li>
-            </ul>
-
-            <h3>Acknowledgements</h3>
-
-            <p><strong>Unhangout</strong> is made possible by the
-            generous support of the MacArthur Foundation and the
-            MIT Media Lab</p>
-        </div>
-
-        <div class="footer">
-            An MIT Media Lab project, in collaboration with the
-            MacArthur Foundation.
-        </div>
+<% include sponsorship.ejs %>
+<% include analytics.ejs %>
 <% include footer.ejs %>
-            

--- a/views/sponsorship.ejs
+++ b/views/sponsorship.ejs
@@ -1,0 +1,4 @@
+        <div class="footer">
+            An MIT Media Lab project, in collaboration with the
+            MacArthur Foundation.
+        </div>


### PR DESCRIPTION
Fixes issue #211.

Rather than using javascript to hide/show the #about div, separate
about and index into separate templates.  To deduplicate, also separate
the sponsorship message and analytics into template stubs so they can be
included in each of the views rather than duplicated.

(An alternative approach that seems heavier than necessary here would be
to invoke a Backbone.Router and unify index/about/how-to-hangout).

On the server, make use of "express.locals" to provide default context
(e.g. {_:_, user:undefined}) to all templates, simplifying "render"
calls.  Remove unused template vars (e.g. "loadApp").
