### PR TITLE
Email error logging; transports set with NODE_ENV

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,115 +7,169 @@ setting up the development environment on Ubuntu/Debian machine.
 A. Installing node.js (any version)
 -----------------------------------
 
-   - Update your system <br>
-     $ sudo apt-get update
-             
-   - Setup the system to handle compiling and installing from source <br>
-     $ sudo apt-get build-essential
-     
-   - To enable SSL support install libssl-dev <br>
-     $ sudo apt-get install libssl-dev
-     
-   - Install curl used by install script<br>
-     $ sudo apt-get install curl
-   
-   - Cloning into node.js repository <br>
-     $ git clone https://github.com/joyent/node.git <br> 
-     $ cd node 
-     
-   - Checkout a specific version of node.js <br>
-     $ git tag # Gives you a list of released versions <br> 
-     $ git checkout v0.9.9 
-     
-   - Compile and install node <br>
-     $ ./configure <br>
-     $ make 
-     $ sudo make install 
-     
-   - To check if the node is installed properly <br>
-     $ node -v <br>
-     $ v0.9.9
-     
-B. Setting up npm (Node Package Management)
--------------------------------------------
+Update your system
 
-  - Install from NPM script using curl <br>
-    $ curl https://npmjs.org/install.sh -L -o -| sh
+    $ sudo apt-get update
+        
+Setup the system to handle compiling and installing from source 
+
+    $ sudo apt-get build-essential
+
+To enable SSL support install libssl-dev 
+
+    $ sudo apt-get install libssl-dev
+
+Install curl used by install script
+
+    $ sudo apt-get install curl
+
+Cloning into node.js repository 
+
+    $ git clone https://github.com/joyent/node.git  
+    $ cd node 
+
+Checkout a specific version of node.js 
+
+    $ git tag # Gives you a list of released versions  
+    $ git checkout v0.9.9 
+
+Compile and install node 
+
+    $ ./configure 
+    $ make 
+    $ sudo make install 
+
+To check if the node is installed properly 
+
+    $ node -v 
+    $ v0.9.9
+     
     
-  - Check npm version <br>
-    $ npm -v <br>
-    $1.3.1
-    
-C. Cloning the Repository.
+B. Cloning the Repository.
 --------------------------
 
   - Clone unhangout repository from github <br>
     $ git clone http://github.com/drewww/unhangout <br>
     $ cd unhangout
+
+C. Install prerequisites.
+-------------------------
+
+Install redis:
+
+    $ sudo apt-get install redis-server 
     
-  - Create a file and copy the contents of conf.json.example file in it. Name this file conf.json. 
-    conf.json.example file contains environment variables to specify server settings.
+Install the required dependencies in local node_modules folder
+
+    $ npm install
+
+If you run selenium tests, install java and download ``selenium-server-standalone.jar`` from https://code.google.com/p/selenium/downloads/list, and specify its location in conf.json under ``TESTING_SELENIUM_PATH``.
+
+
+D. Configuration
+----------------
+    
+Create a file and copy the contents of conf.json.example file in it. Name this file conf.json.  conf.json.example file contains environment variables to specify server settings.
 
     $ touch conf.json <br>
     $ gedit conf.json [copy contents from conf.json.example here]
-    
-    GOOGLE_CLIENT_ID & GOOGLE_CLIENT_SECRET fields are app credentials that can
-    be configured and obtained at http://code.google.com/apis/console/.
-    In the Google API console, you should make a "Client ID for web applications" - that will create
-    the necessary CLIENT_ID and CLIENT_SECRET you need to authenticate with Google and create
-    calendar events.  Set the callback URL to https://localhost:7777/auth/google/callback
-    (swap out the hostname and port with whichever settings you use).
 
-    UNHANGOUT_ADMIN_EMAILS is a list of email addresses which are granted
+  - ``GOOGLE_CLIENT_ID`` and ``GOOGLE_CLIENT_SECRET`` fields are app
+    credentials that can be configured and obtained at
+    http://code.google.com/apis/console/.  In the Google API console, you
+    should make a "Client ID for web applications" - that will create the
+    necessary CLIENT_ID and CLIENT_SECRET you need to authenticate with Google
+    and create calendar events.  Set the callback URL to
+    https://localhost:7777/auth/google/callback (swap out the hostname and port
+    with whichever settings you use).
+
+  - ``UNHANGOUT_ADMIN_EMAILS`` is a list of email addresses which are granted
     "admin" status when they authenticate.  (The server must be restarted and
     clients must re-login to change their admin status).
 
-  - Install data structure redis server <br>
-    $ sudo apt-get install redis-server 
-    
-  - Install the required dependencies in local node_modules folder <br>
-    $ npm install
-
-  - We strongly recommend running the unhangout-server with SSL enabled. Google Hangouts are always run over SSL, and trying to run a hangout application over http causes many browsers to refuse to send requests, which causes a number of insidious issues. 
-    - ensure that UNHANGOUT_USE_SSL in conf.json is set to true.
-    - for development purposes, a self-signed certificate will work fine. These instructions from Heroku are quite good: https://devcenter.heroku.com/articles/ssl-certificate-self If you follow those instructions, you will have two resulting files:
+  - ``UNHANGOUT_REDIS_HOST`` and ``UNHANGOUT_REDIS_PORT`` are the host and port
+    name for the installed redis.  Defaults are ``localhost`` and ``6379``.
+  - ``UNHANOGUT_REDIS_DB`` is an index number pointing to the redis database to
+    use. By default, we use 0 for production.  The unit tests use 1, and will
+    destroy data there.
+  - ``UNHANGOUT_ADMIN_EMAILS`` is a list of email addresses which are granted
+    admin status.
+  - ``UNHANGOUT_HANGOUT_APP_ID`` is the Google app ID for our hangout gadget.
+  - ``UNHANGOUT_USE_SSL``: if true, the server will run with SSL.  We strongly
+    recommend running the unhangout server with SSL, even in development (you
+    can use ``https://localhost:7777/``).  Google Hangouts are always run over
+    SSL, and trying to run a hangout application over http causes many browsers
+    to refuse to send requests, which causes a number of insidious issues. 
+  - ``UNHANGOUT_PRIVATE_KEY`` and ``UNHANGOUT_CERTIFICATE`` are the private key
+    and certificate to use for SSL.  For development purposes, a self-signed
+    certificate will work fine. These instructions from Heroku are quite good:
+    https://devcenter.heroku.com/articles/ssl-certificate-self If you follow
+    those instructions, you will have two resulting files:
       - server.key is your private key, move it to `ssl/` and set the path to that file in UNHANGOUT_PRIVATE_KEY
       - server.crt is your certificate, move it to `ssl/` and set the path to that file in UNHANGOUT_CERTIFICATE
-    - for production purposes, you will need to buy a formal certificate. The Heroku instructions for SSL certificates will show you how to generate a certificate signing request, which you will provide to an SSL issuer: https://devcenter.heroku.com/articles/ssl-endpoint#acquire-ssl-certificate
-      - after submitting the CSR, the certificate provider will issue you a certificate. Put the private key you used to generate the CSR as well as the associated certificate in `ssl/` and set the paths in UNHANGOUT_PRIVATE_KEY and UNHANGOUT_CERTIFICATE to point to those files.
-    - in most production situations, you will want to enable UNHANGOUT_REDIRECT_HTTP. This will start a separate HTTP server that will redirect any requests to their HTTPS equivalent. This presumes that you're using default ports: 80 for HTTP, and 443 for HTTPS, so it requres sudo to bind to privileged ports. In development contexts, set UNHANGOUT_REDIRECT_HTTP to false, and use HTTPS on whatever port you desire.
 
-  - Start the node server and run it in the browser <br>
-    $ npm start <br>
-    $ 127.0.0.1:7777/ [In browser]
+    For production purposes, you will need to obtain a certificate signed by a
+    known certificate authority. Some providers (such as StartSSL) offer free
+    SSL certificates that are recognized by major browsers.  The Heroku
+    instructions for SSL certificates will show you how to generate a
+    certificate signing request, which you will provide to an SSL issuer:
+    https://devcenter.heroku.com/articles/ssl-endpoint#acquire-ssl-certificate
 
-D. Making changes to the codebase
+  - ``HANGOUT_REDIRECT_HTTP``: This will start a separate HTTP server that will
+    redirect any requests to their HTTPS equivalent. This presumes that you're
+    using default ports: 80 for HTTP, and 443 for HTTPS, so it requres sudo to
+    bind to privileged ports. In most production situations, you will want to
+    enable UNHANGOUT_REDIRECT_HTTP. In development contexts, set
+    UNHANGOUT_REDIRECT_HTTP to false, and use HTTPS on whatever port you
+    desire.
+
+  - ``EMAIL_LOG_RECIPIENTS``: When running with the ``NODE_ENV=production``
+    environment variable set, emails reporting any errors logged by the server
+    will be sent to the addresses listed here.
+
+  - ``TESTING_SELENIUM_PATH``: The path to "selenium-server-standalone.jar",
+    required to run tests with selenium.
+
+E. Making changes to the codebase
 ---------------------------------
 
-  - Create a new branch in git unhangout repository <br>
+You can start the node server with:
+
+    $ npm start
+
+and browse the site in ``https://localhost:7777`` (or whichever hosts/ports
+you've configured).  The development workflow for making changes is as follows:
+
+Create a new branch in git unhangout repository
+
     $ git branch branch-name
 
-  - Push the newly created branch on github <br>
+Push the newly created branch on github
+
     $ git push origin branch-name
 
-  - Switch to the new branch <br>
+Switch to the new branch
+
     $ git checkout branch-name
 
-  - Be sure to be in the newly created branch <br>
-    $ git branch <br>
-    $ *branch-name <br>
+Be sure to be in the newly created branch
+
+    $ git branch
+    $ *branch-name
     $  master 
 
-  - Make desired changes in the code base and push them to github <br>
-    $ git add file-name <br>
-    $ git commit -m "commit-message" <br>
-    $ git push origin branch-name <br>
-    Go to github and send a pull request. 
+Make desired changes in the code base and push them to github <br>
 
-E. Testing
+    $ git add file-name
+    $ git commit -m "commit-message"
+    $ git push origin branch-name
+
+Go to github and send a pull request. 
+
+F. Testing
 ----------
 
-Tests use mocha and selenium-webdriver (for live browser tests with Firefox).  To run selenium tests, you must download ``selenium-server-standalone.jar`` from https://code.google.com/p/selenium/downloads/list, and set TESTING_SELENIUM_PATH in conf.json to its path. 
+Tests use mocha and selenium-webdriver (for live browser tests with Firefox).  To run selenium tests, you must download ``selenium-server-standalone.jar`` from https://code.google.com/p/selenium/downloads/list, and set ``TESTING_SELENIUM_PATH`` in ``conf.json`` to its path. 
 
 You can run tests using the npm helper script <br>
 

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -1,12 +1,10 @@
 var models = require('../lib/server-models.js'),
-_ = require('underscore')._;
-sync = require('../lib/redis-sync.js'),
-async = require('async'),
-winston = require('winston'),
-redis = require('redis')
+    _ = require('underscore')._;
+    sync = require('../lib/redis-sync.js'),
+    async = require('async'),
+    logger = require("../lib/logging").getLogger(),
+    redis = require('redis');
 
-
-var logger;
 
 // This file populates the database with basic starter objects to make development easier and more predictable.
 // typically run like this:
@@ -90,37 +88,11 @@ exports.run = function(dbId, redis, callback) {
 }
 
 
-if(require.main === module) 
-{
-    logger = new (winston.Logger)({
-		transports: [
-		new (winston.transports.Console)(
-			{
-				timestamp: true
-			})
-			]
-		});
-		
-	logger.cli();
-
-	logger.info("Called seeds directly; running on main redis db.");
-	
-	models.logger = logger;
-
+if(require.main === module) {
 	var r = redis.createClient();
 	r.on("connect", function() {
 		exports.run(0, r, function() {
 			process.exit();
 		});		
 	})
-} else {
-	logger = new (winston.Logger)({
-		transports: [
-		new (winston.transports.File)(
-			{
-				filename: "seed.log",
-				timestamp: true
-			})
-			]
-		});
 }

--- a/bin/unhangout-server
+++ b/bin/unhangout-server
@@ -3,29 +3,14 @@
 // This file is a lightweight wrapper around unhangout-server.js. It handles
 // configuration loading, creates a server object, and starts it.
 
-var winston = require('winston'),
-	_ = require('underscore')._,
-	server = require('../lib/unhangout-server.js'),
-	fs = require('fs');
+var _ = require('underscore'),
+    logger = require('../lib/logging.js').getLogger(),
+    config = require('../conf.json'),
+	server = require('../lib/unhangout-server.js');
 
 // TODO switch this to a file. Had trouble with getting that working, though.
-var logger= new (winston.Logger)({
-    transports: [
-		new (winston.transports.Console)(
-			{
-			timestamp: true
-			})
-    ],
-});
-
-logger.cli();
 
 logger.info("Starting unhangout-server.");
-
-// load config from conf.json
-var configFile = fs.readFileSync("conf.json", {encoding:"ascii"});
-
-var config = JSON.parse(configFile);
 
 // show all related config variables
 var env = {};
@@ -44,7 +29,7 @@ s.on("inited", function() {
 
 // the extend here is to add defaults to config that we definitely need to have
 // in scope to make choices about how to set up the server.
-s.init(_.extend(env, {"level":"debug", "transport":"console", "mock-auth":false}));
+s.init(_.extend(env, {"mockAuth":false}));
 
 // catch all to make sure uncaught exceptions don't bring down the whole server.
 process.on('uncaughtException', function(err) {

--- a/conf.json.example
+++ b/conf.json.example
@@ -19,5 +19,6 @@
 	"UNHANGOUT_PRIVATE_KEY":"ssl/private.pem",
 	"UNHANGOUT_CERTIFICATE":"ssl/cert.pem",
 
+    "EMAIL_LOG_RECIPIENTS": [],
     "TESTING_SELENIUM_PATH": "bin/selenium-server-standalone.jar"
 }

--- a/lib/hangout-farming.js
+++ b/lib/hangout-farming.js
@@ -2,6 +2,7 @@ var moment = require('moment');
 var googleapis = require('googleapis');
 var GoogleToken = require('gapitoken');
 var OAuth2Client = googleapis.OAuth2Client;
+var logger = require("./logging").getLogger();
 
 var oauth2Client;
 
@@ -88,7 +89,7 @@ exports.init = function(app) {
 						if(!err && "hangoutLink" in event) {
 							// push it into redis for safekeeping. 
 							app.redis.lpush("global:hangout_urls", event.hangoutLink, function(err, num) {
-								app.logger.info("logged new hangout url: " + event.hangoutLink + "; total: " + num);
+								logger.info("logged new hangout url: " + event.hangoutLink + "; total: " + num);
 								// purely for convenience of clicking to farm another url.
 								res.send("urls available: " + num + "<br><a href='//" + app.options.HOST + ":" + app.options.PORT + "/hangout-farming'>CLICK ME</a>");
 								
@@ -120,7 +121,7 @@ exports.init = function(app) {
 		});
 	});
 	
-	app.logger.info("registered hangout-faming urls");
+	logger.info("registered hangout-faming urls");
 }
 
 // get a hangout url from redis
@@ -128,7 +129,7 @@ exports.getNextHangoutUrl = function(callback) {
 	
 	// just hit redis directly here, with an rpop.
 	curApp.redis.rpop("global:hangout_urls", function(err, url) {
-		curApp.logger.debug("returning hangout url: " + url + " (err: " + err + ")");
+		logger.debug("returning hangout url: " + url + " (err: " + err + ")");
 		callback && callback(err, url);
 	});	
 }
@@ -138,7 +139,7 @@ exports.getNextHangoutUrl = function(callback) {
 //  join a new hangout in rapid succession)
 exports.reuseUrl = function(url) {
 	curApp.redis.rpush("global:hangout_urls", url, function(err) {
-		curApp.logger.debug("re-added a url that was no longer needed: " + url);
+		logger.debug("re-added a url that was no longer needed: " + url);
 	});
 }
 

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,45 @@
+var winston = require('winston'),
+    conf = require('../conf.json'),
+    winstonMail = require('winston-mail');
+
+module.exports = {
+    getLogger: function() {
+        logger = new (winston.Logger)();
+        if (process.env.NODE_ENV === "production") {
+            logger.add(winston.transports.File, {
+                filename: __dirname + '/../logs/server.log',
+                level: 'info'
+            });
+            if (conf.EMAIL_LOG_RECIPIENTS && conf.EMAIL_LOG_RECIPIENTS.length > 0) {
+                logger.add(winstonMail.Mail, {
+                    level: 'error',
+                    to: conf.EMAIL_LOG_RECIPIENTS.join(","),
+                    host: conf.EMAIL_LOG_HOST || "localhost",
+                    port: conf.EMAIL_LOG_PORT || (conf.EMAIL_LOG_SECURE ? 587 : 25),
+                    secure: conf.EMAIL_LOG_SECURE || false,
+                    username: conf.EMAIL_LOG_USERNAME || undefined,
+                    password: conf.EMAIL_LOG_PASSWORD || undefined,
+                    silent: false
+                });
+            } else {
+                logger.warn("No EMAIL_LOG_RECIPIENTS specified; skipping email logger transport.")
+            }
+        } else if (process.env.NODE_ENV === "testing") {
+            logger.add(winston.transports.Console, {level: 'crit'});
+            logger.cli();
+        } else {
+            logger.add(winston.transports.Console, {level: 'debug'});
+            logger.cli();
+        }
+        return logger;
+    }
+}
+
+// Run a logging test if we were executed as a script.
+if (require.main === module) {
+    logger = module.exports.getLogger();
+    logger.debug("Test log (level: debug)", {metadata: "fun", level: "debug"});
+    logger.info("Test log (level: info)", {metadata: "fun", level: "info"});
+    logger.warn("Test log (level: warn)", {metadata: "fun", level: "warn"});
+    logger.error("Test log (level: error)", {metadata: "fun", level: "error"});
+}

--- a/lib/server-models.js
+++ b/lib/server-models.js
@@ -1,4 +1,5 @@
 var client_models = require('../public/js/models.js'),
+    logger = require('./logging').getLogger(),
 	_ = require('underscore')._,
     sanitize = require('validator').sanitize,
 	crypto = require('crypto');
@@ -17,12 +18,6 @@ var client_models = require('../public/js/models.js'),
 
 
 exports.USER_KEY_SALT = "SET ME EXTERNALLY";
-
-// dummy logger, set externally
-exports.logger = function() {};
-
-// reference to the server, set externally. 
-exports.server = null;
 
 exports.ServerUser = client_models.User.extend({
 	idRoot: "user",
@@ -77,7 +72,7 @@ exports.ServerUser = client_models.User.extend({
 	},
 	
 	disconnect: function() {
-		exports.logger.info("user:" + this.id + " disconnected.");
+		logger.info("user:" + this.id + " disconnected.");
 		this.set("sock", null);
 		this.trigger("disconnect");
 	},
@@ -87,7 +82,7 @@ exports.ServerUser = client_models.User.extend({
 	// and stringifying. Also checks for some undefined edge cases.
 	write: function(type, args) {
 		if(!this.isConnected()) {
-			exports.logger.warn("Tried to send a message to a user without a socket: " + this.id);
+			logger.warn("Tried to send a message to a user without a socket: " + this.id);
 			return;
 		}
 
@@ -152,8 +147,8 @@ exports.ServerEvent = client_models.Event.extend({
 		// tell everyone that this user has joined
 		this.broadcast("join", {id:this.id, user:user.toJSON()});
 		
-		exports.logger.info("user:" + user.id + " joining event:" + this.id);
-		exports.logger.debug("connected users: " + JSON.stringify(this.get("connectedUsers").pluck("displayName")));
+		logger.info("user:" + user.id + " joining event:" + this.id);
+		logger.debug("connected users: " + JSON.stringify(this.get("connectedUsers").pluck("displayName")));
 		
 		// send the user a bunch of chat messages.
 		this.get("recentMessages").each(function(message) {
@@ -164,7 +159,7 @@ exports.ServerEvent = client_models.Event.extend({
 		// add an on-disconnect listener, so we can clean up after this user when
 		// they disconnect.
 		user.on("disconnect", _.bind(function() {
-			exports.logger.info("user:" + user.id + " leaving event:" + this.id);
+			logger.info("user:" + user.id + " leaving event:" + this.id);
 			this.get("connectedUsers").remove(user);
 			
 			this.broadcast("leave", {id:this.id, user:user.toJSON()});
@@ -292,7 +287,7 @@ exports.ServerSession = client_models.Session.extend({
 		// so we need to disambiguate between starting and stopping by checking
 		// the previous state.
 		this.on("change:hangoutConnected", function() {
-			exports.logger.debug("in change:hangoutConnected " + this.previousAttributes()["hangoutConnected"] + "->" + this.get("hangoutConnected"));
+			logger.debug("in change:hangoutConnected " + this.previousAttributes()["hangoutConnected"] + "->" + this.get("hangoutConnected"));
 
 			if(this.previousAttributes()["hangoutConnected"]==false && this.get("hangoutConnected")==true) {
 				this.trigger("hangout-started");
@@ -320,10 +315,10 @@ exports.ServerSession = client_models.Session.extend({
 			this.heartbeatInterval = setInterval(_.bind(function() {
 				if(_.isNull(this.get("last-heartbeat"))) {
 					this.nullHeartbeatCount++;
-					exports.logger.warn("last-heartbeat was null in a heartbeat check (" + this.nullHeartbeatCount + ")");
+					logger.warn("last-heartbeat was null in a heartbeat check (" + this.nullHeartbeatCount + ")");
 
 					if(this.nullHeartbeatCount>3) {
-						exports.logger.warn("3 null heartbeats in a row, shutting down hangout");
+						logger.warn("3 null heartbeats in a row, shutting down hangout");
 						this.set("hangoutConnected", false);
 					}
 					return;
@@ -334,19 +329,19 @@ exports.ServerSession = client_models.Session.extend({
 				// check and see if the last heartbeat is within the window for
 				// a "live" hangout. if it isn't, shut the hangout down by
 				// changing hangoutConnected to false.
-				exports.logger.debug("time since heartbeat: " + (new Date().getTime() - this.get("last-heartbeat")));
+				logger.debug("time since heartbeat: " + (new Date().getTime() - this.get("last-heartbeat")));
 				if(new Date().getTime() - this.get("last-heartbeat") > 8000) {
-					exports.logger.info("session:" + this.id + " missed a heartbeat, shutting down");
+					logger.info("session:" + this.id + " missed a heartbeat, shutting down");
 					this.set("hangoutConnected", false);
 				} else {
-					exports.logger.debug("session:" + this.id + ":heartbeat-check");
+					logger.debug("session:" + this.id + ":heartbeat-check");
 				}
 			}, this), 6000);
 		}, this));
 
 		// handle a hangout shutting down
 		this.on("hangout-stopped", _.bind(function() {
-			exports.logger.info("hangout shutdown for session " + this.id + ":" + this.get("title"));
+			logger.info("hangout shutdown for session " + this.id + ":" + this.get("title"));
 
 			// clear the connected participants list, too, so it's properly initialized for a future connection.
 			this.set("connectedParticipantIds", []);
@@ -375,7 +370,7 @@ exports.ServerSession = client_models.Session.extend({
 		// the heartbeat checking running properly. 
 
 		if(this.get("hangoutConnected")) {
-			exports.logger.debug("Triggering hangout-started on load.");
+			logger.debug("Triggering hangout-started on load.");
 
 			// this is an annoying hack. it turns out that ServerSession.collection isn't set, because 
 			// in the initialization process sessions are created before they're assigned to events.
@@ -404,7 +399,7 @@ exports.ServerSession = client_models.Session.extend({
 	// trying to start a hangout, and have anyone else who tries to join
 	// wait on their hangout to phone home. 
 	startHangoutWithUser: function(user) {
-		exports.logger.debug("starting hangout with user: " + JSON.stringify(user));
+		logger.debug("starting hangout with user: " + JSON.stringify(user));
 		if(this.isHangoutPending()) {
 			return new Error("Hangout is pending, cannot start it again");
 		} else {
@@ -416,13 +411,13 @@ exports.ServerSession = client_models.Session.extend({
 				obj["userId"] = user.id;
 			} 
 			this.set("hangout-pending", obj);
-			exports.logger.debug("set hangout pending: " + JSON.stringify(this.get("hangout-pending")));
+			logger.debug("set hangout pending: " + JSON.stringify(this.get("hangout-pending")));
 			return true;
 		}
 	},
 	
 	isHangoutPending: function() {
-		exports.logger.debug("checking hangout pending, field: " + JSON.stringify(this.get("hangout-pending")));
+		logger.debug("checking hangout pending, field: " + JSON.stringify(this.get("hangout-pending")));
 		if(_.isNull(this.get("hangout-pending"))) {
 			return false;
 		} else {
@@ -435,7 +430,7 @@ exports.ServerSession = client_models.Session.extend({
 			var obj = this.get("hangout-pending");
 
 			if((new Date().getTime() - obj.time) > 15000) {
-				exports.logger.debug("Hangout pending was too old, returning false and resetting hangout-pending to null.");
+				logger.debug("Hangout pending was too old, returning false and resetting hangout-pending to null.");
 				this.set("hangout-pending", null);
 				return false;
 			}
@@ -448,9 +443,9 @@ exports.ServerSession = client_models.Session.extend({
 	},
 	
 	setHangoutUrl: function(url) {
-		exports.logger.debug("current: " + this.get("hangout-url") + "; setting to: " + url);
+		logger.debug("current: " + this.get("hangout-url") + "; setting to: " + url);
 		if(_.isNull(this.get("hangout-url"))) {
-			exports.logger.debug("setting hangout url: " + url + " and clearing pending. notifying listeners.");
+			logger.debug("setting hangout url: " + url + " and clearing pending. notifying listeners.");
 			this.set("hangout-url", url);
 
 			// if we have a valid hangout url set, mark it as not pending anymore.
@@ -463,7 +458,7 @@ exports.ServerSession = client_models.Session.extend({
 			// the only time I think this will happen is if someone fails to create a hangout within
 			// the creation timeout period (about 30 seconds right now) and then finally does succeed,
 			// and their new hangout tries to register.
-			exports.logger.warn("Got attempt to set hangout-url, with url already valid. Cur url: " + this.get("hangout-url") + "; attempted: " + url);
+			logger.warn("Got attempt to set hangout-url, with url already valid. Cur url: " + this.get("hangout-url") + "; attempted: " + url);
 
 			// TODO it would be nice if they got some sort of warning here, but we don't have a good way
 			// to talk back to their hangout. 
@@ -480,7 +475,7 @@ exports.ServerSession = client_models.Session.extend({
 			this.collection.event.broadcast("session-participants", {id:this.id, participantIds:this.get("connectedParticipantIds")});
 		}
 
-		exports.logger.debug("setting connected participants to: " + participantIds);
+		logger.debug("setting connected participants to: " + participantIds);
 	},
 
 	heartbeat: function(participants, url, startTime) {
@@ -496,8 +491,8 @@ exports.ServerSession = client_models.Session.extend({
 
 		// if the heartbeat doesn't include participants and url, still ignore it.
 		if(!this.get("hangoutConnected") && participants && url) {
-			exports.logger.warn("HEARTBEAT FOR ENDED SESSION: " + this.id + "; " + this.get("session-key"));
-			exports.logger.warn("Restarting session, with participants: " + participants + "; url: " + url);
+			logger.warn("HEARTBEAT FOR ENDED SESSION: " + this.id + "; " + this.get("session-key"));
+			logger.warn("Restarting session, with participants: " + participants + "; url: " + url);
 
 			this.setConnectedParticipantIds(participants);
 			this.setHangoutUrl(url);
@@ -509,9 +504,9 @@ exports.ServerSession = client_models.Session.extend({
 		// also make sure the stored value isn't null; if it's null, then all systems
 		// nominal - this is a normal uncontested restart.
 		if(startTime && !_.isNull(this.get("hangout-start-time")) && (startTime != this.get("hangout-start-time"))) {
-			exports.logger.error("Received a heartbeat from a hangout with a mismatched start time: " + startTime + "; storedStartTime: " + this.get("hangout-start-time"));
-			exports.logger.error("This is a critical issue, and represents a rogue hangout!");
-			exports.logger.error("The URL for the other hangout is: " + url);
+			logger.error("Received a heartbeat from a hangout with a mismatched start time: " + startTime + "; storedStartTime: " + this.get("hangout-start-time"));
+			logger.error("This is a critical issue, and represents a rogue hangout!");
+			logger.error("The URL for the other hangout is: " + url);
 
 			// if the startTime in this heartbeat is less than the stored one,
 			// then this heartbeat comes from the blessed session; we always prefer older
@@ -547,7 +542,7 @@ exports.ServerSession = client_models.Session.extend({
 	// people don't want to name their new session themselves.
 	generateCreationKey: function() {
 		if(this.get("creationKey")) {
-			exports.logger.warn("Trying to generate a creation key for a session that already had one.");
+			logger.warn("Trying to generate a creation key for a session that already had one.");
 			return;
 		}
 

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -1,4 +1,4 @@
-var winston = require('winston'),
+var logger = require('./logging').getLogger(),
 	_ = require('underscore')._,
 	EventEmitter = require('events').EventEmitter,
 	redis_lib = require('redis'),
@@ -18,7 +18,6 @@ var winston = require('winston'),
 var models = require('./server-models.js'),
 	client_models = require('../public/js/models.js');
 
-var logger;
 var mockAdmin;
 
 // This is the primary class that represents the UnhangoutServer.
@@ -59,66 +58,16 @@ exports.UnhangoutServer.prototype = {
 	
 	unauthenticatedSockets: null,	// sockets currently in limbo; connected but unauthenticated
 	
-	logger: null,			// logger helper object
-	
 	init: function(options) {
-		// the models package needs a reference to the current server object
-		// for various activities, particularly sending messages to connected
-		// clients.
-		models.server = this;
-		
 		if(_.isUndefined(options)) {
 			options = {};
 		}
 		
 		// apply default options if they're not provided.
 		// (otherwise, they will come from conf.json)
-		this.options = _.defaults(options, {"level":"debug", "transport":"console", "HOST":"localhost", "PORT":7777,
+		this.options = _.defaults(options, {"HOST":"localhost", "PORT":7777,
 			"REDIS_HOST":"localhost", "REDIS_PORT":6379, "SESSION_SECRET":"fake secret", "REDIS_DB":0, "persist":true,
 			"mock-auth":false, "mock-auth-admin":false, "timeoutHttp":false});
-
-		// this piece manages different logger transport options. Either it
-		// outputs logging information to the console (good for development)
-		// or to a file (good for production). This also manages logging level,
-		// so you can switch between info and debug level logging if desired.
-		var transports = [];
-		switch(this.options.transport) {
-			case "console":
-				transports.push(new (winston.transports.Console)({
-						timestamp: true,
-						json: false,
-						level: this.options.level
-					}));
-				break;
-			case "file":
-				transports.push(new (winston.transports.File)({
-							filename: 'server.log',
-							timestamp: true,
-							json: false,
-							level: this.options.level
-						}));
-				break;
-		}
-		
-		logger = new (winston.Logger)({transports:transports});
-		models.logger = logger;
-		this.logger = logger;
-		
-		if(this.options.transport=="console") {
-			// this .cli() call is a little helper method provided by winston
-			// to format logging messages nicely for console output with colors
-			// and tabs and stuff.
-			logger.cli();
-
-			// make sure all transports include a timestamp on each message
-			// (.cli() turns this off, annoyingly, so we have to turn it on
-			// again after we call .cli())
-			_.each(logger.transports, function(transport) {
-				transport.timestamp = true;
-			})
-		}
-
-		logger.info("Logging setup!");
 
 		if(this.options["mock-auth-admin"]) {
 			mockAdmin = true;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "node ./bin/unhangout-server",
     "setup": "source conf.sh",
-    "test": "mocha",
+    "test": "NODE_ENV=testing mocha",
     "forever-start": "sudo forever start --minUptime 1000 --spinSleepTime 1000 -a -l unhangout.log -o out.log -e err.log bin/unhangout-server",
     "forever-stop": "sudo forever stop bin/unhangout-server",
     "forever-restart": "sudo forever restart bin/unhangout-server",
@@ -31,6 +31,7 @@
   	"commander" :  "2.0.0",
     "express"   :  "3.3.5",
   	"winston"   :  "0.7.2",
+    "winston-mail": "0.2.7",
   	"sockjs"    :  "0.3.7",
   	"underscore":  "1.5.1",
   	"node-uuid" :  "1.3.3",

--- a/test/common.js
+++ b/test/common.js
@@ -55,7 +55,7 @@ exports.standardSetup = function(done) {
     exports.server.on("started", done);
     
     seed.run(1, redis, function() {
-        exports.server.init({"transport":"file", "level":"debug", "GOOGLE_CLIENT_ID":true, "GOOGLE_CLIENT_SECRET":true, "REDIS_DB":1, "timeoutHttp":true});      
+        exports.server.init({"GOOGLE_CLIENT_ID":true, "GOOGLE_CLIENT_SECRET":true, "REDIS_DB":1, "timeoutHttp":true});      
     });
 }
 exports.mockSetup = function(admin, callback) {
@@ -75,7 +75,7 @@ exports.mockSetup = function(admin, callback) {
         }
 
         seed.run(1, redis, function() {
-            exports.server.init({"transport":"file", "level":"debug", "GOOGLE_CLIENT_ID":true, "GOOGLE_CLIENT_SECRET":true, "REDIS_DB":1, "mock-auth":true, "mock-auth-admin":admin, "timeoutHttp":true});       
+            exports.server.init({"GOOGLE_CLIENT_ID":true, "GOOGLE_CLIENT_SECRET":true, "REDIS_DB":1, "mock-auth":true, "mock-auth-admin":admin, "timeoutHttp":true});       
         });
     }
 };

--- a/test/test.models.js
+++ b/test/test.models.js
@@ -2,8 +2,6 @@ var models = require('../lib/server-models.js'),
 	client_models = require('../public/js/models.js'),
 	should = require('should');
 
-models.logger = {warn: function() {}, info: function() {}, debug: function(){}};
-
 describe("SERVEREVENT", function() {
 	describe("#new", function() {
 		it('should construct a default model', function() {

--- a/test/test.server.js
+++ b/test/test.server.js
@@ -54,7 +54,7 @@ describe('unhangout server', function() {
 			s.on("inited", function() {
 				should.fail("Expected an error.");
 			});
-			s.init({"transport":"file", "level":"debug"});
+			s.init({});
 		});
 		
 		it('#start should fail if init is not called first', function(done) {

--- a/test/test.sync.js
+++ b/test/test.sync.js
@@ -1,18 +1,9 @@
 var models = require('../public/js/models.js'),
-	winston = require('winston'),
 	sync = require('../lib/redis-sync.js'),
-	redis = require('redis').createClient();
+	redis = require('redis').createClient(),
+    logger = require('../lib/logging').getLogger(),
 	should = require('should');
 
-var logger= new (winston.Logger)({
-    transports: [
-		new (winston.transports.File)(
-			{
-			filename: "test.log",
-			timestamp: true
-			})
-    ]
-});
 
 var event;
 


### PR DESCRIPTION
Refactor the loging configuration into a single file, `lib/logging.js`, which can be required by any module that wants the standard logging configuration.  This eliminates the need for `unhangout-server` to hold a public reference to the logger and assign it to other components, and removes the many invocations of winston.

Eliminate the logging transport and level options sent to unhangout-server's `init`.  Instead, use the NODE_ENV environment variable to determine transport and level options.  Use the following NODE_ENV conventions:
- NODE_ENV=production : log to file at level INFO, and send emails on error.
- NODE_ENV=testing : log at level CRIT to console.
- else: log at level DEBUG to console.

`npm test` now invokes `NODE_ENV=testing mocha`; invoking mocha directly without setting the `NODE_ENV` will result in default console logging during tests.  In production, the NODE_ENV=production
environment var must be set to configure logging properly.

Pertinent to issue #130.
