### PR TITLE
Split unhangout-server.js into 7 files

### DIFF
--- a/lib/hangout-farming.js
+++ b/lib/hangout-farming.js
@@ -6,29 +6,29 @@ var logger = require("./logging").getLogger();
 
 var oauth2Client;
 
-var curApp;
+var curDb;
 
 var numHangoutUrlsAvailable = 0;
 
 // The rationale for this crazy situation is covered in DEVELOPMENT.md
 
-exports.init = function(app) {
-	curApp = app;
+exports.init = function(app, db, options) {
+	curDb = db;
 	
 	// keep track of the total number of hangout urls we've farmed so far, so we
 	// can put it in the UI.
-	app.redis.llen('global:hangout_urls', function(err, len) {
+	db.redis.llen('global:hangout_urls', function(err, len) {
 		numHangoutUrlsAvailable = len;
 	});
 
 	// set up an HTTP endpoint that will put us in the endpoint redirect loop
 	// people who load this url 
-	app.express.get('/hangout-farming', function(req, res){
-		var url = req.protocol + "://" + app.options.HOST + ":" + app.options.PORT + "/hangout-callback";
+	app.get('/hangout-farming', function(req, res){
+		var url = req.protocol + "://" + options.HOST + ":" + options.PORT + "/hangout-callback";
 
 		// initialize an oauth client request, using our google client id
 		oauth2Client =
-		new OAuth2Client(app.options.GOOGLE_CLIENT_ID, app.options.GOOGLE_CLIENT_SECRET, url);
+		new OAuth2Client(options.GOOGLE_CLIENT_ID, options.GOOGLE_CLIENT_SECRET, url);
 
 		var url = oauth2Client.generateAuthUrl({
 			access_type: 'offline',
@@ -43,7 +43,7 @@ exports.init = function(app) {
 	// from google, after they authorize our app. The request they make back to
 	// our server will have a token attached to it, that we will use to 
 	// place requests on behalf of this user.
-	app.express.get('/hangout-callback', function(req, res) {
+	app.get('/hangout-callback', function(req, res) {
 		// console.log(req.query["code"]);
 		oauth2Client.getToken(req.query["code"], function(err, token) {
 			if(err) {
@@ -88,10 +88,10 @@ exports.init = function(app) {
 						// event object.
 						if(!err && "hangoutLink" in event) {
 							// push it into redis for safekeeping. 
-							app.redis.lpush("global:hangout_urls", event.hangoutLink, function(err, num) {
+							db.redis.lpush("global:hangout_urls", event.hangoutLink, function(err, num) {
 								logger.info("logged new hangout url: " + event.hangoutLink + "; total: " + num);
 								// purely for convenience of clicking to farm another url.
-								res.send("urls available: " + num + "<br><a href='//" + app.options.HOST + ":" + app.options.PORT + "/hangout-farming'>CLICK ME</a>");
+								res.send("urls available: " + num + "<br><a href='//" + options.HOST + ":" + options.PORT + "/hangout-farming'>CLICK ME</a>");
 								
 								// update the tracking number.
 								numHangoutUrlsAvailable = num;
@@ -112,7 +112,7 @@ exports.init = function(app) {
 								// we send this error if the calendar event created doesn't have a hangout url
 								// included in the object. Give the user some rudimentary instructions about
 								// how to fix this situation.
-								res.send("your account doesn't seem to have the 'create video calls for events I create' option enabled. go to <a href='http://calendar.google.com'>google calendar</a>, settings (in the upper right hand corner) and enable that option. Then <a href='http://" + app.options.HOST + ":" + app.options.PORT + "/hangout-farming'>CLICK HERE!</a><br>" + JSON.stringify(event));
+								res.send("your account doesn't seem to have the 'create video calls for events I create' option enabled. go to <a href='http://calendar.google.com'>google calendar</a>, settings (in the upper right hand corner) and enable that option. Then <a href='http://" + options.HOST + ":" + options.PORT + "/hangout-farming'>CLICK HERE!</a><br>" + JSON.stringify(event));
 							}
 						}
 					});
@@ -128,7 +128,7 @@ exports.init = function(app) {
 exports.getNextHangoutUrl = function(callback) {
 	
 	// just hit redis directly here, with an rpop.
-	curApp.redis.rpop("global:hangout_urls", function(err, url) {
+	curDb.redis.rpop("global:hangout_urls", function(err, url) {
 		logger.debug("returning hangout url: " + url + " (err: " + err + ")");
 		callback && callback(err, url);
 	});	
@@ -138,7 +138,7 @@ exports.getNextHangoutUrl = function(callback) {
 // (this situation occurs in some limited situations where people
 //  join a new hangout in rapid succession)
 exports.reuseUrl = function(url) {
-	curApp.redis.rpush("global:hangout_urls", url, function(err) {
+	curDb.redis.rpush("global:hangout_urls", url, function(err) {
 		logger.debug("re-added a url that was no longer needed: " + url);
 	});
 }

--- a/lib/passport-mock.js
+++ b/lib/passport-mock.js
@@ -39,7 +39,7 @@ var mockUsers = {
 
 exports.mockAuthMiddleware = function(server) {
     _.each(mockUsers, function(user) {
-        server.users.add(new models.ServerUser(user));
+        server.db.users.add(new models.ServerUser(user));
     });
 
     function mockAuth(req, res, next) {
@@ -52,7 +52,7 @@ exports.mockAuthMiddleware = function(server) {
             // unauthenticated.
             return next();
         }
-        req.user = server.users.findWhere({"sock-key": mock_user});
+        req.user = server.db.users.findWhere({"sock-key": mock_user});
         next();
     };
     return mockAuth;

--- a/lib/permalink-routes.js
+++ b/lib/permalink-routes.js
@@ -1,0 +1,157 @@
+var _ = require("underscore"),
+    utils = require("./utils"),
+    models = require("./server-models"),
+    logger = require("./logging").getLogger();
+
+var ensureAdmin = utils.ensureAdmin
+
+module.exports = {
+    route: function(app, db, options) {
+		//---------------------------------------------------------//
+		//						PERMALINKS 						   //
+		//---------------------------------------------------------//
+
+		app.get("/h/", function(req, res) {
+			res.render('permalink-intro.ejs');
+		});
+
+		app.get("/h/admin/:code/:key", function(req, res) {
+			var session = db.permalinkSessions.find(function(s) {
+				return s.get("shortCode")===req.params.code;
+			});
+
+			if(_.isUndefined(session)) {
+				logger.warn("Request for /h/admin/:code/:key with unknown session code: " + req.params.code);
+				res.status(404);
+				res.send();
+				return;
+			}
+
+			if(req.params.key===session.get("creationKey")) {
+				// now render the normal permalink view, but with the admin interface showing.
+				res.render('permalink.ejs', {showAdmin: true, users:db.users, session:session });
+			} else {
+				logger.warn("Attempt to load /h/admin/:code/:key with invalid key for this session: " + req.params.key);
+				res.status(403);
+				res.send();
+				return;
+			}
+
+		});
+
+		app.get("/h/:code", function(req, res) {
+			logger.debug("GET /h/" +req.params.code + ": " + JSON.stringify(req.body))
+			// okay, this is the permalink part of the site. if this key exists already,
+			// then render an appropriate template immediately. if we don't have a 
+			// session that matches this code, then create one and then render
+			// the page.
+
+			// validate shortcodes here. 
+			var re = /^[A-Za-z0-9-_.+]*$/;
+			if(!re.test(req.params.code)) {
+				logger.warn("GET /h/" + req.params.code + " is not a valid hangout permalink");
+				res.status(400);
+				res.send();
+				return;
+			}
+
+
+			var session = db.permalinkSessions.find(function(s) {
+				return s.get("shortCode")===req.params.code;
+			});
+
+			if(_.isUndefined(session)) {
+				logger.debug("No session found for shortcode: '" + req.params.code + "', creating a new one.");
+				session = new models.ServerSession();
+
+				session.set("isPermalinkSession", true);
+
+				// use the specified code for the new session.
+				session.set("shortCode", req.params.code);
+				db.permalinkSessions.add(session);
+				session.generateCreationKey();
+				session.set("first-load", true);
+				session.save();
+
+				// now redirect them to the admin page for this session.
+				logger.info("Redirecting to admin page for a new permalink session code.");
+				res.redirect("/h/admin/" + req.params.code + "/" + session.get("creationKey"));
+				return;
+			}
+
+			// the problem with this is that we don't actually have all users in the
+			// hangout in our list of users. That only includes people who have logged
+			// in here. Not sure what to do about this. We'll either have to force
+			// people to google log in when they land on the page, OR we're
+			// going to have to have the participant information sent from the
+			// hangout app instead of just the ids involved.
+
+			res.render('permalink.ejs', {showAdmin: false, users:db.users, session:session});
+
+			// after rendering, drop the first-load 
+			if(session.get("first-load")) {
+				session.set("first-load", false);
+				session.save();
+			}
+		});
+		
+		app.post("/h/admin/:code", function(req, res) {
+			logger.info("POST /h/admin/"+ req.params.code + ": " + JSON.stringify(req.body));
+			if(!("creationKey" in req.body)) {
+				res.status(400);
+				res.send();
+				return;
+			}
+
+			// otherwise, if creationKey is present, check it against the specified session.
+			var session = db.permalinkSessions.find(function(s) {
+				return s.get("shortCode")==req.params.code;
+			});
+
+			if(_.isUndefined(session)) {
+				logger.warn("sess:unknown (set title/desc)" + JSON.stringify(req.body));
+				res.status(404);
+				res.send();
+				return;
+			}
+
+			if(req.body.creationKey===session.get("creationKey")) {
+				session.set("title", req.body.title);
+				session.set("description", req.body.description);
+				session.save();
+
+				logger.debug("updating session with params: " + JSON.stringify(req.body));
+
+				res.redirect("/h/" + req.params.code);
+			} else {
+				logger.warn("POST to /h/admin/:code with invaid creationKey.");
+				res.status(403);
+				res.send();
+				return;
+			}
+		});
+
+		// this endpoint manually stops a shortcode session.
+		// we seem to occasionally get sessions that are broken and stay open when
+		// they're supposed to be closed. this lets us fix that issue.
+		// this checks global admin status, not per-shortcode admin status.
+		// we could at some point add this in to the permalink admin page, but I don't
+		// think people actually go back to that.
+		app.post("/h/:code/stop", ensureAdmin, function(req, res) {
+			var session = db.permalinkSessions.find(function(s) {
+				return s.get("shortCode")==req.params.code;
+			});
+
+			if(_.isUndefined(session)) {
+				logger.warn("sess:unknown (stop)" + JSON.stringify(req.body));
+				res.status(404);
+				res.send();
+				return;
+			}
+
+			// this will cascasde to trigger hangout-stopped, since we're hard-triggering a stop.
+			session.set("hangoutConnected", false);
+			res.redirect("/admin");
+		});
+    }
+}

--- a/lib/redirect-https.js
+++ b/lib/redirect-https.js
@@ -1,0 +1,14 @@
+var http = require("http"),
+    logger = require("./logging").getLogger(),
+    express = require("express");
+
+module.exports = function() {
+    var redirect = express();
+    var server = http.createServer(redirect);
+    redirect.all("*", function(req, res) {
+        logger.info("Redirecting HTTP to HTTPS: " + req.url);
+        res.redirect("https://" + req.headers["host"] + req.url);
+    });
+    server.listen(80);
+    logger.info("Started HTTP redirect server on 80");
+};

--- a/lib/unhangout-db.js
+++ b/lib/unhangout-db.js
@@ -1,0 +1,137 @@
+var logger = require('./logging').getLogger(),
+    _ = require('underscore'),
+    events = require('events'),
+    redis_lib = require('redis'),
+    async = require('async'),
+    models = require("./server-models"),
+    sync = require('./../lib/redis-sync');
+
+var UnhangoutDb = function(options) {
+    this.options = options;
+};
+
+_.extend(UnhangoutDb.prototype, events.EventEmitter.prototype, {
+    init: function(callback) {
+        _.bindAll(this, "loadModels");
+
+        var redis = redis_lib.createClient(parseInt(this.options.REDIS_PORT), this.options.REDIS_HOST);
+        this.users = new models.ServerUserList();
+        this.events = new models.ServerEventList();
+        this.permalinkSessions = new models.ServerSessionList();
+
+        redis.auth(this.options.REDIS_PASSWORD);
+        redis.on("end", function() { logger.error("redis end"); });
+        redis.on("error", function() { logger.error("redis error: " + err); });
+        redis.on("ready", function() { logger.info("redis ready"); });
+        redis.once("ready", _.bind(function(err) {
+            if (err) {
+                logger.error("Error connecting to redis: " + err);
+                this.emit("error", "Error connecting to redis: " + err);
+                return callback && callback(err);
+            }
+            
+            redis.select(this.options.REDIS_DB, _.bind(function() {
+                sync.init(logger, redis);
+                sync.setPersist(this.options.persist);
+                this.loadModels(_.bind(function(err) {
+                    if (err) {
+                        logger.error("Error loading models from redis: " + err);
+                    } else {
+                        logger.info("Loaded " + this.users.length + " users from redis.");
+                        logger.info("loaded " + this.events.length + " events from redis.");
+                        var counter = 0;
+                        this.events.each(function(event) {
+                            counter += event.get("sessions").length;
+                        });
+                        logger.info("Loaded " + counter + " sessions from redis.");
+                        this.emit("inited");
+                    }
+                    callback && callback(err);
+                }, this));
+            }, this));
+        }, this));
+        this.redis = redis;
+
+    },
+    loadModels: function(callback) {
+        // Okay, this looks scary but it's relatively simple.  Basically, the
+        // loaders set up methods that we call with a simple JS object
+        // representing each of the objects of that type in redis. It simply
+        // needs to construct matching objects. This drives the crazy async
+        // engine that follows. To add a new type, just add a matching entry in
+        // loaders and follow the format.
+        
+        var loaders = {
+            "user/*":_.bind(function(callback, attrs, key) {
+                var newUser = new models.ServerUser(attrs);
+                // no need to save since we're pulling from the
+                // database to begin with.
+                this.users.add(newUser);
+                callback();
+            }, this),
+            
+            "event/?????":_.bind(function(callback, attrs, key) {
+                var newEvent = new models.ServerEvent(attrs);               
+                this.events.add(newEvent);
+                callback();
+            }, this),
+            
+            "event/*/sessions/*":_.bind(function(callback, attrs, key) {
+                var eventId = parseInt(key.split("/")[1]);
+
+                var event = this.events.get(eventId);
+                var newSession = new models.ServerSession(attrs);
+                event.addSession(newSession);
+                
+                callback();
+            }, this),
+
+            "session/permalink/*":_.bind(function(callback, attrs, key) {
+                var newSession = new models.ServerSession(attrs);
+
+                // force these to be true. This fixes a transient condition where some
+                // keys in the db didn't have this set and it defaults to false.dw
+                newSession.set("isPermalinkSession", true);
+
+                this.permalinkSessions.add(newSession);
+                callback();
+            }, this)
+        };
+        
+        // This mess is doing three things:
+        // 1) figuring out all the key names of all the objects of this type in redis
+        // 2) running mget to grab all those json strings at once
+        // 3) calling the loader callbacks with parsed versions of those JSON strings
+        //
+        // It seems worse than it is because of annoying async/map/bind wrappers, but
+        // that's just to get all the closures configured right.
+        async.series(_.map(_.pairs(loaders), _.bind(function(loader) {
+            return _.bind(function(callback) {
+                logger.info("loading " + loader[0]);
+                this.redis.keys(loader[0], _.bind(function(err, modelKeys) {
+                    if(modelKeys.length==0) {
+                        callback(err);
+                        return;
+                    }
+                    this.redis.mget(modelKeys, _.bind(function(err, modelsJSON) {
+                        async.parallel(_.map(modelsJSON, _.bind(function(modelJSON, index) {
+                            var key = modelKeys[index];
+                            return _.bind(function(callback) {
+                                var attrs = JSON.parse(modelJSON);
+                                loader[1](callback, attrs, key);
+                            }, this);
+                        }, this)), function(err, result) {
+                            callback();
+                        });
+                    }, this));
+                }, this));
+            }, this);
+        }, this)), function(err, results) {
+            logger.info("Done loading models.");
+            callback();
+        });
+
+    }
+});
+
+module.exports = UnhangoutDb;

--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -1,0 +1,540 @@
+var _ = require("underscore"),
+    passport = require("passport"),
+    logger = require("./logging").getLogger(),
+    models = require("./server-models"),
+    farming = require('./hangout-farming.js'),
+    utils = require("./utils");
+
+var ensureAuthenticated = utils.ensureAuthenticated;
+var ensureAdmin = utils.ensureAdmin;
+var getSession = utils.getSession;
+
+module.exports = {
+
+    route: function(app, db, options) {
+        // routing for the homepage
+        app.get("/", function(req, res) {
+            res.render('index.ejs', {user: req.user});
+        });
+
+        app.get("/about/", function(req, res) {
+            res.render('about.ejs', {user: req.user});
+        });
+
+        app.get("/how-to-unhangout/", function(req, res) {
+            res.render('how-to-unhangout.ejs', {user: req.user});
+        });
+        
+        // routing for events
+        // make sure they're authenticated before they join the event.
+        app.get("/event/:id", ensureAuthenticated, function(req, res) {
+            // we'll accept either event ids OR shortName fields, for more readable
+            // urls. 
+
+            // lets figure out if it's an integer or not.
+            var id;
+            var e;
+            // per http://stackoverflow.com/questions/1019515/javascript-test-for-an-integer
+            var intRegex = /^\d+$/;
+            if(intRegex.test(req.params.id)) {
+                id = parseInt(req.params.id);
+                e = db.events.get(id);
+                logger.debug("Found event by id.");
+            } else {
+                // if the reg ex fails, try searching shortnames.
+                // (this is inefficient, but still pretty darn cheap in
+                //  node.)
+                // side: we're assuming shortNames are unique, but I don't
+                // think we actually enforce that anywhere. eeek.
+                var eventsWithShortName = db.events.filter(function(event) {
+                    if(event.has("shortName") && !_.isNull(event.get("shortName"))) {
+                        return event.get("shortName").localeCompare(req.params.id)==0;
+                    } else {
+                        return false;
+                    }
+                });
+
+                if(eventsWithShortName.length > 1) {
+                    logger.warn("Found more than one event with the short name '" + req.params.id = "': " + JSON.stringify(eventsWithShortName));
+                } else if(eventsWithShortName.length==1) {
+                    e = eventsWithShortName[0];
+                } else {
+                    logger.warn(":id was not an integer, and specified short name was not found.");
+                }
+            }
+
+            if(_.isUndefined(e)) {
+                logger.warn("Request for a non-existent event id: " + req.params.id);
+                res.status(404);
+                res.send();
+                return;
+            }
+
+            var context = {user:req.user, event:e};
+            if(!_.isUndefined(farming)) {
+                context["numFarmedHangouts"] = farming.getNumHangoutsAvailable();
+            }
+
+            res.render('event.ejs', context);
+        });
+        
+        // the passport middleware (passport.authenticate) should route this request to
+        // google, and not call the rendering callback below.
+        app.get("/auth/google", passport.authenticate('google', {
+                scope: [
+                    'https://www.googleapis.com/auth/userinfo.profile',
+                    'https://www.googleapis.com/auth/userinfo.email']
+            }),
+            function(req, res) {
+                logger.warn("Auth request function called. This is unexpected! We expect this to get routed to google instead.");
+            }
+        );
+        
+        // after a user authenticates at google, google will redirect them to this url with
+        // an authentication token that is consumed by passport.authenticate. 
+        app.get("/auth/google/callback", passport.authenticate('google'),
+            function(req, res) {
+
+                // if post-auth-path was set, send them to that path now that authentication
+                // is complete.
+                if("post-auth-path" in req.session) {
+                    var path = req.session["post-auth-path"];
+                    delete req.session["post-auth-path"];
+                    res.redirect(path);
+                } else {
+                    res.redirect("/");
+                }
+            }
+        );
+        
+        app.get("/logout", function(req, res) {
+            req.logout();
+            res.redirect("/");
+        });
+        
+        // this endpoint connects someone to the hangout for a particular session.
+        // the :id in this case is not an actual session id, instead we use
+        // session-keys for this. (getSession checks for both)
+        // we do this for authentication reasons, so someone can't arbitrarily
+        // join a session hangout that isn't started yet or that they're
+        // not supposed to have access to. It's a little thing - anyone
+        // with access can send the link to anyone else - but it's better
+        // than nothing.
+        app.get("/session/:id", function(req, res) {
+            var session = getSession(req.params.id, db.events, db.permalinkSessions);
+            logger.info("ROUTING TO SESSION: " + JSON.stringify(session));
+
+            if(session) {
+                // three options at this point:
+                // 1. the session is already running and has a hangout link populated -> redirect to hangout
+                // 2. the session doesn't have a hangout link, but does have someone pending on starting the hangout -> stall, wait for response
+                // 3. the session doesn't have a hangout link, and doesn't yet have a pending link -> send to google
+                
+                // TWO BIG OPTIONS HERE
+                // If we have a farmed url available, prefer that significantly; it resolves a bunch of our issues.
+                // so check with the farming module / redis to see if we can do taht. 
+                // If that returns an error, then do the fallback strategy, which is to get the first person to click it
+                // to generate the session and have that session phone home.
+                
+                if(session.getHangoutUrl()) {
+                    logger.info("redirecting user to existing hangout url: " + session.getHangoutUrl());
+
+                    // append all the google hangout app info to enforce loading it on startup
+                    res.redirect(session.getHangoutUrl());
+                } else {
+                    var farmedSesssionURL = farming.getNextHangoutUrl(function(err, url) {
+                        if(err || url==null) {
+                            logger.warn("ran out of farmed hangout urls! falling back to first-visitor->redirect strategy. isPending? " + session.isHangoutPending());
+                            // this branch is for the situation when there is no farmed hangout url available.
+                            if(session.isHangoutPending()) {
+                                logger.debug("session is pending, waiting on someone else to do it");
+                                // if it's pending, wait on the hangout-url event.
+                                // logger.debug("waiting for hangout URL to return for request from user: " + req.user.id);
+                                session.once("hangout-url", function(url) {
+                                    logger.info("issueing redirect to requests waiting for a hangout link to be created: " + url);
+                                    // when we get the hangout url, redirect this request to it.
+                                    res.redirect(url);
+                                });
+                            } else {
+                                // if there isn't a pending request, this is the first user to hit this link.
+                                // send them to google!
+                                logger.info("session " + req.params.id + " does not yet have a hangout, and is not pending. sending user " + _.isUndefined(req.user) ? "[id missing]" : req.user.id + " to go make a new hangout.");
+                                session.startHangoutWithUser(req.user);
+                                logger.info(session.get("session-key"));
+
+                                var url = "https://plus.google.com/hangouts/_" + generateSessionHangoutGDParam(session, options);
+                                logger.debug("redirecting to: " + url);
+                                res.redirect(url);
+                            }
+                        } else {
+                            // double check that we haven't already set a url on this session
+                            //        this would happen if two requests came in identically and
+                            //         resolved first. 
+                            if(session.getHangoutUrl()) {
+                                // and push the url we were going to use back on the end of the 
+                                // queue.
+                                logger.warning("encountered a race condition where we over-requested hangout urls for a new hangout. putting the extra one back in the list.");
+                                farming.reuseUrl(url);
+                            } else {
+                                var fullURL = url + generateSessionHangoutGDParam(session, options);
+                                logger.debug("redirecting to: " + fullURL);
+                                session.set("hangout-url", fullURL);
+                            }
+                            logger.info("pulled a new hangout url off the stack; redirecting user to that url: " + url);
+                            res.redirect(session.getHangoutUrl());
+                        }
+                    });
+                }
+            } else {
+                logger.warn("request for unknown session id: " + req.params.id);
+                res.status(404);
+                res.send();
+            }
+        });
+
+        // all messages from the hangout app running in each of the active hangouts
+        // go to this endpoint. 
+        // TODO verify that this is using session keys, not sessionids (otherwise it would
+        // be super easy to spoof)
+        // TODO think about whether we want more security here. the right thing
+        // to do would be to require some sort of handshake on election so the keys
+        // for posting hangout messages aren't the same as the ones public to all
+        app.post("/session/hangout/:id", _.bind(function(req, res) {
+            logger.debug("POST /session/hangout/" + req.params.id + ":" + req.body.type)
+            // TODO need to switch this over to searching through session-keys in the events' domains using _.find
+            if(!("id" in req.params)) {
+                res.status(404);
+                res.send();
+                return;
+            }
+
+            var session = getSession(req.params.id, db.events, db.permalinkSessions);
+            
+
+            if(_.isUndefined(session)) {
+                logger.warn("session:unknown " + JSON.stringify(req.body) + " for key " + req.params.id);
+                res.status(400);
+                res.send();
+                return;
+            }
+
+            // make sure a type is specified
+            if(!("type" in req.body)) {
+                res.status(400)
+                res.send();
+                return;
+            }
+
+            // STOP DOING THIS it's causing major problems
+            // any message to a non-hangout-connected session should make it 
+            // be connected.
+            // if(!session.get("hangoutConnected")) {
+            //  session.set("hangoutConnected", true);
+            // }
+
+            switch(req.body.type) {
+                // in the hangout-farming situation, this behavior of the app is basically vestigal.
+                // the server already knows what the url should be, and auto-assigns it before the
+                // hangout actually loads. But if we're not farming, this is critical, because the
+                // first loader needs to set the actual hangout url.
+                //
+                // this request is called for every person who loads a hangot. only the first one
+                // really has any functional impact, though. subsequent loads will ignore the
+                // setHangoutUrl piece because the hangout already has a url.
+                case "loaded":
+                    if(session && "url" in req.body) {
+                        logger.info("session:" + session.id + ":loaded\tparticipant:" + JSON.stringify(req.body.participant) + "\tparticipants: " + JSON.stringify(req.body.participants) + "\tkey: " + req.params.id + "\turl: " + req.body.url);
+
+                        // get the post data; we're expecting the url to be in the payload.
+                        var url = req.body.url;
+                        logger.info("loaded url: " + url + " (url set in session: " + session.getHangoutUrl() + ")");
+
+                        if(!session.get("hangoutConnected")) {
+                            logger.info("first load of session, starting it up!");
+                            session.set("hangoutConnected", true);
+                        }
+
+                        // set the start time, but only if it hasn't been set yet.
+                        if(_.isNull(session.get("hangout-start-time")) || _.isUndefined(session.get("hangout-start-time"))) {
+                            session.set("hangout-start-time", req.body.startTime);
+                            session.save();
+                        }
+
+                        // the session will ignore this if it already has a url.
+                        var fullURL = url + generateSessionHangoutGDParam(session, options);
+                        // logger.debug("(trying to) set hangout url to: " + fullURL);
+                        session.setHangoutUrl(fullURL);
+
+
+                        res.status(200);
+                        res.send();
+                    } else {
+                        logger.warn("request for unknown session id: " + req.params.id + " or missing payload: " + JSON.stringify(req.body));
+                        res.status(404);
+                        res.send();
+                    }
+
+                    break;
+
+                // sent any time someone joins or leaves a hangout. contains the full
+                // participant list every time.
+                case "participants":
+                    // update the current participant list for this session. 
+                    if(session && "participants" in req.body) {
+
+                        // we need to look and see if we have this user id in our db.users
+                        // list. if we don't, we need to keep track of them somehow. not
+                        // sure exactly where to put this just yet.
+                        var participantIds = _.map(req.body.participants, function(participant) {
+                            return participant.person.id;
+                        });
+
+                        // TODO start checking to see if we have all these participants in our user list
+                        // and if their id is not tracked in users, add them in. This will help us rendering
+                        // their pictures elsewhere in the app without much trouble.
+                        _.each(req.body.participants, _.bind(function(participant) {
+                            if(_.isUndefined(db.users.get(participant.person.id))) {
+                                logger.debug("creating new user object");
+
+                                var newUserAttrs = {displayName:participant.person.displayName,
+                                    id:participant.person.id};
+
+                                if(participant.person.image) {
+                                    newUserAttrs["picture"] = participant.person.image.url;
+                                }
+
+                                var newUser = new models.ServerUser(newUserAttrs);
+                                newUser.set("createdViaHangout", true);
+                                db.users.add(newUser);
+                                newUser.save();
+                            } else {
+                                // TODO perhaps add a flag that this user was seen in a permalink
+                                // based hangout? 
+                            }
+                        }, this));
+
+                        logger.info("session:" + session.id + ":participants\t" + JSON.stringify(participantIds));
+
+                        session.setConnectedParticipantIds(participantIds);
+
+                        // count this as a heartbeat, since it represents active hangout activity. Useful since
+                        // the first heartbeat isn't for 5 seconds, and in some situations there might be an 
+                        // extant heartbeat-check interval running that could fire before this new participant
+                        // picks up heartbeat responsibilities.
+                        session.heartbeat();
+                    } else {
+                        logger.warn("Received a request for participants missing appropriate session key or participants field.");
+                        res.status(404);
+                        res.send();
+                    }
+                    break;
+                // hangouts send heartbeats every 5 seconds so we can tell that the
+                // hangout is still running. this is because there is not a reliable
+                // "closing hangout" message, so we have to infer it from heartbeats
+                // disappearing.
+                case "heartbeat":
+                    logger.debug("session:" + session.id + ":heartbeat\tfrom:" + req.body.from + "\tparticipants: " + JSON.stringify(req.body.participants) + "\turl: " + req.body.url + "\tstartTime: " + req.body.startTime + "\tfromLeader: " + req.body.fromLeader);
+                    var err = session.heartbeat(req.body.participants, req.body.url + generateSessionHangoutGDParam(session, options), req.body.startTime);
+
+                    if(err) {
+                        logger.error("Sending fail to newer hangout session!");
+
+                        res.status(200);
+                        res.send("FAIL");
+
+                        // drop out to avoid hitting later status/send calls.
+                        return;
+                    }
+
+                    break;
+                default: 
+                    logger.warn("Got unknown hangout post: " + JSON.stringify(req.body));
+                    break;
+            }
+            // after whatever manipulation we've done, save the session.
+            session.save();
+
+
+            // Close out the requests successfully, assuming that if anything else were wrong
+            // they would have been closed out and the method returned earlier in execution.
+            res.status(200);
+            res.send();
+        }, this));
+
+        app.post("/subscribe", _.bind(function(req, res) {
+            logger.debug("POST /subscribe");
+
+            // save subscription emails
+            if("email" in req.body && req.body.email.length > 5 && req.body.email.length < 100) {
+                //TODO: move any redis-specific stuff to unhangout-db.
+                db.redis.lpush("global:subscriptions", req.body.email);
+                logger.info("subscribed email: " + req.body.email);
+                res.status(200);
+                res.send();
+            } else {
+                res.status(400);
+                res.send();
+            }
+        }, this));
+
+        app.get("/admin", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            logger.info("GET /admin");
+
+            var sortedPermalinkSesssions = db.permalinkSessions.sortBy(function(s) {
+                return s.get("user-seconds") * -1;
+            });
+
+            sortedPermalinkSesssions = _.sortBy(sortedPermalinkSesssions, function(s) {
+                return s.get("connectedParticipantIds").length * -1;
+            });
+
+            // now prepend all event sessions 
+            var sessions = _.flatten(db.events.map(function(event) {
+                if(event.isLive()) {
+                    return event.get("sessions").toArray();
+                } else {
+                    return [];
+                }
+            }));
+
+            var allSessions = sessions.concat(sortedPermalinkSesssions);
+
+            res.render('admin.ejs', {user:req.user, events:db.events, sessions:allSessions, event:undefined });
+        }, this));
+
+        app.get("/admin/event/new", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            logger.debug("GET /admin/event/new");
+            var event = db.events.get(req.params.id);
+
+            var context = {user:req.user, events:db.events, event:event, create:true};
+
+            res.render('admin-event.ejs', context);
+        }, this));
+
+        app.post("/admin/event/new", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            logger.debug("POST /admin/event/new " + JSON.stringify(req.body));
+
+            // make sure title and description are present, otherwise reject the request.
+            if(!("title" in req.body) || !("description" in req.body)) {
+                res.status(400);
+                res.send();
+                return;
+            }
+
+            var event = new models.ServerEvent({title:req.body.title, shortName:req.body.shortName, description:req.body.description,
+                    welcomeMessage:req.body.welcomeMessage, organizer:req.body.organizer});
+
+            event.save();
+            db.events.add(event);
+
+            logger.info("Created a new event: " + JSON.stringify(event));
+
+            res.redirect("/admin");
+        }, this));
+
+        app.post("/admin/event/:id/start", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            var event = db.events.get(req.params.id);
+
+            if(_.isUndefined(event)) {
+                logger.warn("Attempt to stop unknown event id: " + req.params.id);
+                res.status(404);
+                res.send();
+                return;
+            };
+
+            var err = event.start();
+
+            if(err) {
+                res.status(500);
+                res.send(err);
+                return;
+            }
+
+            logger.info("Started event:" + req.params.id);
+
+            res.redirect("/admin/");
+        }, this));
+
+        app.post("/admin/event/:id/stop", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            var event = db.events.get(req.params.id);
+
+            if(_.isUndefined(event)) {
+                logger.warn("Attempt to start unknown event id: " + req.params.id);
+                res.status(404);
+                res.send();
+                return;
+            };
+
+            var err = event.stop();
+            if(err) {
+                res.status(500);
+                res.send(err);
+                return;
+            }
+
+            logger.info("Stopped event:" + req.params.id);
+
+            res.redirect("/admin/");
+        }, this));
+
+        app.get("/admin/event/:id", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            var event = db.events.get(req.params.id);
+
+            if(_.isUndefined(event)) {
+                logger.warn("Attempt to load unknown event id: " + req.params.id);
+                res.status(404);
+                res.send();
+                return;
+            };
+
+            res.render('admin-event.ejs', {user:req.user, events:db.events, event:event, _:_, loadApp:false, create:false})
+        }, this));
+
+
+        app.post("/admin/event/:id", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
+            var event = db.events.get(req.params.id);
+
+            if(_.isUndefined(event)) {
+                logger.warn("Attempt to update unknown event id: " + req.params.id);
+                res.status(404);
+                res.send();
+                return;
+            };
+
+            var shouldBroadcast = false;
+
+            if(event.get("description")!=req.body.description) {
+                shouldBroadcast = true;
+            }
+
+            // now we need to update everything...
+            event.set("title", req.body.title);
+            event.set("shortName", req.body.shortName);
+            event.set("description", req.body.description);
+            event.set("welcomeMessage", req.body.welcomeMessage);
+            event.set("organizer", req.body.organizer);
+            event.set("blurDisabled", req.body.blurDisabled);
+            event.save();
+
+            logger.debug("new event attributes: " + JSON.stringify(event));
+
+            if(shouldBroadcast) {
+                event.broadcast("event-update", event.toJSON());
+            }
+
+            res.redirect("/admin/event/" + event.id);
+        }, this));
+
+        app.get("/");
+    }
+}
+
+function generateSessionHangoutGDParam(session, options) {
+    // logger.debug("generating url for session: " + JSON.stringify(session));
+
+    // replace : with | in any free-text field like title and description
+    return "?gid="+options.HANGOUT_APP_ID + 
+        "&gd=" + options.HOST + ":" + options.PORT + ":" + 
+        session.get("session-key") +':'+ encodeURIComponent(session.get('title').replace(":", "|")) +':'+ encodeURIComponent(session.get("isPermalinkSession") ? session.get('description').replace(":", "|") : "none") +':'+
+        session.get('shortCode') + ':' + session.get("isPermalinkSession") + ':' + encodeURIComponent(session.collection.event ? session.collection.event.get("title").replace(":", "|") : "none");
+}

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -1,8 +1,13 @@
 var logger = require('./logging').getLogger(),
 	_ = require('underscore')._,
 	EventEmitter = require('events').EventEmitter,
-	redis_lib = require('redis'),
-	sync = require('./../lib/redis-sync.js'),
+    UnhangoutDb = require('./unhangout-db'),
+    UnhangoutSocketManager = require('./unhangout-sockets').UnhangoutSocketManager,
+    unhangoutRoutes = require('./unhangout-routes'),
+    permalinkRoutes = require('./permalink-routes'),
+    models = require('./server-models.js'),
+    utils = require('./utils'),
+	farming = require('./hangout-farming.js'),
 	async = require('async'),
 	express = require('express'),
 	RedisStore = require('connect-redis')(express),
@@ -10,12 +15,8 @@ var logger = require('./logging').getLogger(),
 	https = require('https'),
 	passport = require('passport'),
 	GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
-	farming = require('./../lib/hangout-farming.js'),
-	fs = require('fs'),
-	sockjs_lib = require('sockjs');
 
-var models = require('./server-models.js'),
-	client_models = require('../public/js/models.js');
+	fs = require('fs');
 
 // This is the primary class that represents the UnhangoutServer.
 // I organize the server pieces into a class so we can more easily
@@ -45,15 +46,6 @@ exports.UnhangoutServer.prototype = {
 	
 	express: null,			// reference to the http express wrapper
 	http: null,				// reference to the node http server base object
-	sockjs: null,			// reference to the sockjs server
-	redis: null,			// reference to redis connection
-	
-	permalinkSessions: null,
-
-	users: null,			// backbone collection of known users (loaded on startup)
-	events: null,			// backbone collection of known events (loaded on startup)
-	
-	unauthenticatedSockets: null,	// sockets currently in limbo; connected but unauthenticated
 	
 	init: function(options) {
 		if(_.isUndefined(options)) {
@@ -81,75 +73,14 @@ exports.UnhangoutServer.prototype = {
 		// TODO is it bad for this to be the same as the session secret? leaving the same for now.
 		models.USER_KEY_SALT = this.options.SESSION_SECRET;
 		
-		this.unauthenticatedSockets = {};
+        this.db = new UnhangoutDb(options);
+        this.db.init(_.bind(function(err) {
+            if (!err) {
+                this.inited = true;
+                this.emit("inited");
+            }
+        }, this));
 		
-		// create the big global collections
-		this.users = new models.ServerUserList();
-		this.events = new models.ServerEventList();
-		this.permalinkSessions = new models.ServerSessionList();
-
-		//----------------------------//
-		//			redis setup		  //
-		//----------------------------//
-		this.redis = redis_lib.createClient(parseInt(this.options.REDIS_PORT), this.options.REDIS_HOST);
-
-    // console.log(this.options.REDIS_PASSWORD);
-    this.redis.auth(this.options.REDIS_PASSWORD);
-		
-		this.redis.on("end", function() {
-			logger.error("redis end");
-		});
-
-		this.redis.on("error", function(err) {
-			logger.error("redis error: " + err);
-		});
-
-		this.redis.on("ready", function() {
-			logger.info("redis ready");
-		});
-
-		// make sure only to run this once, otherwise we trigger
-		// all the stuff that happens AFTER redis sets up a second time.
-		this.redis.once("ready", _.bind(function(err) {
-			if(err) {
-				logger.error("Error connecting to redis: " + err);
-				this.emit("error", "Error connecting to redis: " + err, err);
-				return;
-			}
-			
-			this.inited = true;
-			logger.info("UnhangoutServer initialized.");
-
-			// the select call scopes us to a particular redis db, so we can
-			// plausibly run this on separate a separate DB for testing or
-			// for running multiple concurrent instances or whatever.
-			this.redis.select(this.options.REDIS_DB, _.bind(function(err, res) {
-				if(err) this.emit("error", err);
-				
-				// setup redis sync -> backbone models
-				sync.init(logger, this.redis);
-				sync.setPersist(this.options.persist);
-				
-				// kick off the model loading from redis.
-				this.initializeModelsFromRedis(_.bind(function(err) {
-					if(err) {
-						logger.err("Error loading models from redis: " + err);
-					} else {
-						logger.info("Loaded " + this.users.length + " users from redis.");
-						logger.info("Loaded " + this.events.length + " events from redis.");
-						
-						var counter = 0;
-						this.events.each(function(event) {
-							counter += event.get("sessions").length;
-						});
-						
-						logger.info("Loaded " + counter + " sessions from redis.");
-						
-						this.emit("inited");	
-					}
-				}, this));
-			}, this));
-		}, this));
 	},
 	
 	start: function() {
@@ -181,352 +112,16 @@ exports.UnhangoutServer.prototype = {
 
 			this.http = https.createServer({key:privateKey, cert:cert}, this.express);
 			logger.log("info", "Created HTTPS server");
-
-			if(this.options.REDIRECT_HTTP) {
-				// set up a dedicated http server just to redirect to https
-				var redirect = express();
-				this.httpRedirect = http.createServer(redirect);
-				redirect.all("*", function(req, res) {
-					logger.info("Redirecting HTTP request to HTTPS: " + req.url);
-					res.redirect("https://" + req.headers["host"] + req.url);
-				});
-				this.httpRedirect.listen(80);
-				logger.info("Started HTTP redirect server on 80");
-			}
 		} else {
 			this.http = http.createServer(this.express);
 			logger.log("info", "Created HTTP server");
 		}
+        if(this.options.REDIRECT_HTTP) {
+            this.httpRedirect = require("./redirect-https")();
+        }
 
-		// create a sockjs server, and shim their default built in logging behavior
-		// into our standard logger.
-		this.sockjs = sockjs_lib.createServer({
-			"log":function(severity, message) {
-				logger.log("debug", severity + ": " + message);
-			},
-			"disconnect_delay": this.options.disconnect_delay
-		});
-		
-		// when we get a new sockjs connection, register it and set up 
-		this.sockjs.on('connection', _.bind(function(conn) {			
-		    logger.info('connection' + conn);
-					
-			// flag the connection as unauthenticated until we get an authentication message.
-			conn.authenticated = false;
-			
-			// this can be helpful for debugging purposes, to have separate distinct
-			// connection ids.
-			conn.id = Math.floor(Math.random()*10000000);
-			
-			// put this connection in the unauthenticated list
-			this.unauthenticatedSockets[conn.id] = conn;
-		
-			// when the connection closes, make sure the user object 
-			// hears about it.
-		    conn.once('close', _.bind(function() {
-				if(conn.authenticated) {
-					logger.info("closing id: " + conn.id);
-					conn.user.disconnect();
-				} else {
-					// if they never authenticated, just clean out the unauthenticated
-					// sockets list.
-					delete this.unauthenticatedSockets[conn.id];
-				}
-		    }, this));
-			
-			// this is where the primary protocol specification lives. whenever
-			// we get a message FROM a client, this method is called. Messages
-			// arive as raw strings.
-
-		    conn.on('data', _.bind(function(string) {
-
-				// TODO wrap this in error handling
-
-				// reject messages that don't JSON parse
-				var message;
-				try {
-					message = JSON.parse(string);
-				} catch (e) {
-					logger.warn("Error parsing message from client: " + string);
-					return;
-				}
-
-				// reject messages that don't have a "type" field
-				if(!("type" in message)) {
-					logger.warn("Received message without 'type' key: " + string);
-					return;
-				}
-				var user;
-
-				// switch on the message type
-				//
-				// Each message type has some similar components.
-				// First, we check for relevant arguments that we need to have
-				// to execute the command. Then we assemble the relevant objects
-				// for the operation, ie the user object and session object if
-				// a user is trying to sign up for a session. Finally,
-				// we execute the action on the object, eg call "attend" on the
-				// session with the specified user object. 
-				//
-				// We try whenever possible to return descriptive error messages
-				// if something about the arguments is wrong. 
-				switch(message.type) {
-					case "auth":
-						// expecting: "id" and "key"
-						if("id" in message.args && "key" in message.args) {
-							
-							user = this.users.get(message.args.id);
-							
-							if(_.isUndefined(user)) {
-								logger.warn("User presented unrecognized id: " + message.args.id);
-								writeErr(conn, "auth");
-								return;
-							}
-							
-							// this is the bulk of the command here; we're checking
-							// that the key presented in the message is the same as
-							// by the user in .getSockKey() - which is called during
-							// page load by the templating engine. That sets the key
-							// in the server-side user object, and then we check that
-							// it matches here. 
-
-							if(user.validateSockKey(message.args.key)) {
-								logger.info("AUTHENTICATED sock " + conn.id + " to user " + user.id);
-								conn.authenticated = true;
-								// TODO send a message to the client acknowledging.
-								
-								// since the socket is now authenticated, remove it
-								// from the unauthenticated pool.
-								delete this.unauthenticatedSockets[conn.id];
-								
-								user.setSock(conn);
-								conn.user = user;
-								
-								writeAck(conn, "auth");
-							} else {
-								logger.warn("Invalid key presented for user " + user.id);
-								writeErr(conn, "auth");
-							}
-							
-						} else {
-							logger.warn("Missing 'id' or 'key' in AUTH message payload.");
-							writeErr(conn, "auth");
-							return;
-						}
-						break;
-					case "join":
-						// mark which event page they're on
-						user = conn.user;
-						
-						// check arguments
-						if(!("id" in message.args)) {
-							user.writeErr("join");
-							return;
-						}
-						
-						// confirm the event to be joined exists
-						// the getEvent wrapper abstracts this process,
-						// including sending error messages to the client
-						// if the event doesn't exist (as specified in
-						// msg.args)
-						var event = this.events.get(message.args.id);
-						if(_.isUndefined(event)) {
-							user.write("join-err", "Invalid event id.");
-							return;
-						}
-
-						// if(event instanceof Error) return;
-												
-						// join it!
-						// this will generate the relevant broadcast messages
-						// to tell other users that someone has joined. 
-						event.userConnected(user);
-						user.writeAck("join");
-						break;
-					case "create-session":
-						user = conn.user;
-
-						// enforce admin-ness of the user who is trying to 
-						// create a session. 
-						if(!user.isAdmin()) {
-							logger.warn("User " + user.id + " tried to create-session, but is not an admin.");
-							user.writeErr("create-session");
-							return;
-						}
-						
-						var event = getEvent(message, user, "create-session");
-						if(event instanceof Error) return;
-
-						if("title" in message.args && "description" in message.args) {
-							// make the new session!
-							var newSession = new models.ServerSession({"title":message.args.title, "description":message.args.description});
-							newSession.save();
-
-							// once the id has been set in the save process,
-							// add the session to the event.
-							logger.debug("pre bind");
-							newSession.on("change:id", _.once(function() {
-								// the broadcast happens in addSession, as does the event save.
-								event.addSession(newSession);
-							}));
-
-							user.writeAck("create-session");
-						} else {
-							user.writeErr("create-session", "Missing name or description in arguments.");
-						}
-						
-						break;
-					case "chat":
-						user = conn.user;
-						
-						if(!("text" in message.args)) {
-							user.writeErr("chat", "missing text in chat message");
-							return;
-						}
-						
-						var event = getEvent(message, user, "chat");
-						if(event instanceof Error) return;
-												
-						try {
-							event.sendChatFromUser(message.args.text, user)							;
-							user.writeAck("chat");
-						} catch (e) {
-							user.writeErr("chat");
-						}
-						
-						break;
-
-					case "delete":
-						user = conn.user;
-						if(!user.isAdmin()) {
-							logger.warn("User " + user.id + " tried to delete, but is not an admin.");
-							user.writeErr("delete");
-							return;
-						}
-						
-						var event = getEvent(message, user, "delete");
-						if(event instanceof Error) return;
-						
-						var session = getSessionFromMessage(message, user, event, "delete");
-						if(session instanceof Error) return;
-						
-						session.destroy();
-						event.removeSession(session);
-						logger.info("Removed session: " + session.id + " from event " + event.id);
-						user.writeAck("delete");
-						event.save();
-						break;
-
-					case "open-sessions":
-						user = conn.user;
-						if(!user.isAdmin()) {
-							logger.warn("User " + user.id + " tried to open sessions, but is not an admin.");
-							user.writeErr("open-sessions");
-							return;
-						}
-
-						var event = getEvent(message, user, "open-sessions");
-						if(event instanceof Error) return;
-
-						event.openSessions();
-
-						user.writeAck("open-sessions");
-						event.save();
-						break;
-
-					case "close-sessions":
-						user = conn.user;
-						if(!user.isAdmin()) {
-							logger.warn("User " + user.id + " tried to open sessions, but is not an admin.");
-							user.writeErr("close-sessions");
-							return;
-						}
-
-						var event = getEvent(message, user, "close-sessions");
-						if(event instanceof Error) return;
-
-						event.closeSessions();
-						user.writeAck("close-sessions");
-
-						event.save();
-						break;
-
-					// sets the current video embed. An empty string is considered
-					// no embed. 
-					case "embed":
-						user = conn.user;
-						if(!user.isAdmin()) {
-							logger.warn("User " + user.id + " tried to set embed, but is not an admin.");
-							user.writeErr("embed");
-							return;
-						}
-
-						var event = getEvent(message, user, "embed");
-						if(event instanceof Error) return;
-												
-						if("ytId" in message.args) {
-							event.setEmbed(message.args.ytId);
-							user.writeAck("embed");
-							event.save();
-						} else {
-							user.writeErr("embed");
-						}
-
-						break;
-
-					// blur and focus are just mini state change events on
-					// the user object. they help users track who has the
-					// lobby window as their fore-ground window, and who has
-					// switched to some other window (probably a hangout)
-					// nothing fancy here, just flipping a bit in the user
-					// object.
-					case "blur":
-						 user = conn.user;
-
-						if(!("id" in message.args)) {
-							user.writeErr("blur", "missing id in args");
-							return;
-						}
-						
-						var event = getEvent(message, user, "blur");
-						if(event instanceof Error) return;
-						
-						user.setBlurred(true);
-						
-						break;
-
-					case "focus":
-						 user = conn.user;
-
-						if(!("id" in message.args)) {
-							user.writeErr("focus", "missing id in args");
-							return;
-						}
-						
-						var event = getEvent(message, user, "focus");
-						if(event instanceof Error) return;
-						
-						user.setBlurred(false);
-
-						break;
-
-					default:
-						logger.warn("Server does not handle '" + message.type + "' type events.");
-						break;
-				}
-
-				logger.info("message:" + user.id + ":" + message.type + "  " + JSON.stringify(message.args));
-
-		    }, this));
-		}, this));
-		
-		logger.info("sockjs server created");
-		
-		// sockjs negotiates its startup process over http. so, we need to
-		// tell it where in our routing it should put its endpoints.
-		this.sockjs.installHandlers(this.http, {prefix:'/sock'});
-		
-		logger.info("\tsock thandlers installed");
+        this.socketManager = new UnhangoutSocketManager(this.http, this.db, this.options);
+        this.socketManager.init();
 		
 		// passport is a library we use for doing google authentication. it
 		// abstracts the process of redirecting people to google and dealing
@@ -542,7 +137,7 @@ exports.UnhangoutServer.prototype = {
 			// Add this newly callback-ed user to our list of known users.
 			delete profile["_raw"];
 
-			logger.debug("users.length" + this.users.length);
+			logger.debug("users.length" + this.db.users.length);
 			
 			// Minor note: this whole block assumes that a user can't possibly exist
 			// in the database. There is, actually, a case where they WILL exist.
@@ -552,12 +147,12 @@ exports.UnhangoutServer.prototype = {
 			// permissions from that user to access their google plus account.
 			var newUser = new models.ServerUser(profile);
 
-			var oldUser = this.users.get(newUser.id);
+			var oldUser = this.db.users.get(newUser.id);
 			if(!_.isUndefined(oldUser)) {
 				logger.warn("Found an existing user with id " + newUser.id + " in our user list. It will be replaced. Old user attributes: " + oldUser.attributes);
 			}
 			// we're not really going to do anything special here, except note it in the logs.
-			this.users.remove(oldUser);
+			this.db.users.remove(oldUser);
 
 			// a google plus profile can have more than one email. check
 			// all of them to see if any of them are an admin email.
@@ -570,9 +165,9 @@ exports.UnhangoutServer.prototype = {
 			}, this));
 			
 			newUser.save();
-			this.users.add(newUser);
+			this.db.users.add(newUser);
 
-			logger.debug("users.length" + this.users.length);
+			logger.debug("users.length" + this.db.users.length);
 
 			return done(null, newUser.toJSON());
 		}, this)));
@@ -586,7 +181,7 @@ exports.UnhangoutServer.prototype = {
 		
 		// this part gets existing users from memory
 		passport.deserializeUser(_.bind(function(id, done) {
-			var user = this.users.get(id);
+			var user = this.db.users.get(id);
 			if(_.isNull(user)) {
 				logger.error("Tried to deserialize a user that did not exist; user:" + id);
 				done(new Error('user/' + id + " does not exist."));
@@ -595,7 +190,7 @@ exports.UnhangoutServer.prototype = {
 			}
 		}, this));
 		
-		var redisSessionStore = new RedisStore({client:this.redis});
+		var redisSessionStore = new RedisStore({client:this.db.redis});
 		
 		// setup the templating engine
 		this.express.engine('.ejs', require('ejs').__express);
@@ -625,685 +220,26 @@ exports.UnhangoutServer.prototype = {
 
 		// allow cross domain posting from google hangout apps
 		// this should be more specific than "*", but the CORS protocol is
-		// quite stingy in what it will accept here: http://stackoverflow.com/questions/14003332/access-control-allow-origin-wildcard-subdomains-ports-and-protocols
+		// quite stingy in what it will accept here:
+        // http://stackoverflow.com/questions/14003332/access-control-allow-origin-wildcard-subdomains-ports-and-protocols
 		// what we really want to do is allow https requests if we're in https mode, and http request
 		// if not, and only from *.googleusercontent.com, but that's proving to be very
 		// tricky to get to work. For now, leaving this as a wildcard, though we
-		// definitely need to look it down more later.
-		this.express.use(allowCrossDomain("*"));
+		// definitely need to lock it down more later.
+		this.express.use(utils.allowCrossDomain("*"));
+
+        //
+        // Routes
+        //
 
 		// do static serving from /public 
 		this.express.use("/public", express.static(__dirname + "/../public"));
-		
-		// routing for the homepage
-		this.express.get("/", _.bind(function(req, res) {
-			res.render('index.ejs', {user: req.user});
-		}, this));
 
-		this.express.get("/about/", _.bind(function(req, res) {
-			res.render('about.ejs', {user: req.user});
-		}, this));
-
-		this.express.get("/how-to-unhangout/", _.bind(function(req, res) {
-			res.render('how-to-unhangout.ejs', {user: req.user});
-		}, this));
-		
-		// routing for events
-		// make sure they're authenticated before they join the event.
-		this.express.get("/event/:id", ensureAuthenticated, _.bind(function(req, res) {
-			// we'll accept either event ids OR shortName fields, for more readable
-			// urls. 
-
-			// lets figure out if it's an integer or not.
-			var id;
-			var e;
-			// per http://stackoverflow.com/questions/1019515/javascript-test-for-an-integer
-			var intRegex = /^\d+$/;
-			if(intRegex.test(req.params.id)) {
-				id = parseInt(req.params.id);
-				e = this.events.get(id);
-				logger.debug("Found event by id.");
-			} else {
-				// if the reg ex fails, try searching shortnames.
-				// (this is inefficient, but still pretty darn cheap in
-				//  node.)
-				// side: we're assuming shortNames are unique, but I don't
-				// think we actually enforce that anywhere. eeek.
-				var eventsWithShortName = this.events.filter(function(event) {
-					if(event.has("shortName") && !_.isNull(event.get("shortName"))) {
-						return event.get("shortName").localeCompare(req.params.id)==0;
-					} else {
-						return false;
-					}
-				});
-
-				if(eventsWithShortName.length > 1) {
-					logger.warn("Found more than one event with the short name '" + req.params.id = "': " + JSON.stringify(eventsWithShortName));
-				} else if(eventsWithShortName.length==1) {
-					e = eventsWithShortName[0];
-				} else {
-					logger.warn(":id was not an integer, and specified short name was not found.");
-				}
-			}
-
-			if(_.isUndefined(e)) {
-				logger.warn("Request for a non-existent event id: " + req.params.id);
-				res.status(404);
-				res.send();
-				return;
-			}
-
-			var context = {user:req.user, event:e};
-			if(!_.isUndefined(farming)) {
-				context["numFarmedHangouts"] = farming.getNumHangoutsAvailable();
-			}
-
-			res.render('event.ejs', context);
-		}, this));
-		
-		// the passport middleware (passport.authenticate) should route this request to
-		// google, and not call the rendering callback below.
-		this.express.get("/auth/google", passport.authenticate('google', {
-                scope: [
-                    'https://www.googleapis.com/auth/userinfo.profile',
-                    'https://www.googleapis.com/auth/userinfo.email']
-            }),
-			function(req, res) {
-				logger.warn("Auth request function called. This is unexpected! We expect this to get routed to google instead.");
-			}
-		);
-		
-		// after a user authenticates at google, google will redirect them to this url with
-		// an authentication token that is consumed by passport.authenticate. 
-		this.express.get("/auth/google/callback", passport.authenticate('google'),
-			function(req, res) {
-
-				// if post-auth-path was set, send them to that path now that authentication
-				// is complete.
-				if("post-auth-path" in req.session) {
-					var path = req.session["post-auth-path"];
-					delete req.session["post-auth-path"];
-					res.redirect(path);
-				} else {
-					res.redirect("/");
-				}
-			}
-		);
-		
-		this.express.get("/logout", function(req, res) {
-			req.logout();
-			res.redirect("/");
-		});
-		
-		// this endpoint connects someone to the hangout for a particular session.
-		// the :id in this case is not an actual session id, instead we use
-		// session-keys for this. (getSession checks for both)
-		// we do this for authentication reasons, so someone can't arbitrarily
-		// join a session hangout that isn't started yet or that they're
-		// not supposed to have access to. It's a little thing - anyone
-		// with access can send the link to anyone else - but it's better
-		// than nothing.
-		this.express.get("/session/:id", _.bind(function(req, res) {
-			var session = getSession(req.params.id, this.events, this.permalinkSessions);
-			logger.info("ROUTING TO SESSION: " + JSON.stringify(session));
-
-			if(session) {
-				// three options at this point:
-				// 1. the session is already running and has a hangout link populated -> redirect to hangout
-				// 2. the session doesn't have a hangout link, but does have someone pending on starting the hangout -> stall, wait for response
-				// 3. the session doesn't have a hangout link, and doesn't yet have a pending link -> send to google
-				
-				// TWO BIG OPTIONS HERE
-				// If we have a farmed url available, prefer that significantly; it resolves a bunch of our issues.
-				// so check with the farming module / redis to see if we can do taht. 
-				// If that returns an error, then do the fallback strategy, which is to get the first person to click it
-				// to generate the session and have that session phone home.
-				
-				if(session.getHangoutUrl()) {
-					logger.info("redirecting user to existing hangout url: " + session.getHangoutUrl());
-
-					// append all the google hangout app info to enforce loading it on startup
-					res.redirect(session.getHangoutUrl());
-				} else {
-					var farmedSesssionURL = farming.getNextHangoutUrl(_.bind(function(err, url) {
-						if(err || url==null) {
-							logger.warn("ran out of farmed hangout urls! falling back to first-visitor->redirect strategy. isPending? " + session.isHangoutPending());
-							// this branch is for the situation when there is no farmed hangout url available.
-							if(session.isHangoutPending()) {
-								logger.debug("session is pending, waiting on someone else to do it");
-								// if it's pending, wait on the hangout-url event.
-								// logger.debug("waiting for hangout URL to return for request from user: " + req.user.id);
-								session.once("hangout-url", _.bind(function(url) {
-									logger.info("issueing redirect to requests waiting for a hangout link to be created: " + url);
-									// when we get the hangout url, redirect this request to it.
-									res.redirect(url);
-								}, this));
-							} else {
-								// if there isn't a pending request, this is the first user to hit this link.
-								// send them to google!
-								logger.info("session " + req.params.id + " does not yet have a hangout, and is not pending. sending user " + _.isUndefined(req.user) ? "[id missing]" : req.user.id + " to go make a new hangout.");
-								session.startHangoutWithUser(req.user);
-								logger.info(session.get("session-key"));
-
-								var url = "https://plus.google.com/hangouts/_" + generateSessionHangoutGDParam(session, this.options);
-								logger.debug("redirecting to: " + url);
-								res.redirect(url);
-							}
-						} else {
-							// double check that we haven't already set a url on this session
-							//		this would happen if two requests came in identically and
-							// 		resolved first. 
-							if(session.getHangoutUrl()) {
-								// and push the url we were going to use back on the end of the 
-								// queue.
-								logger.warning("encountered a race condition where we over-requested hangout urls for a new hangout. putting the extra one back in the list.");
-								farming.reuseUrl(url);
-							} else {
-								var fullURL = url + generateSessionHangoutGDParam(session, this.options);
-								logger.debug("redirecting to: " + fullURL);
-								session.set("hangout-url", fullURL);
-							}
-							logger.info("pulled a new hangout url off the stack; redirecting user to that url: " + url);
-							res.redirect(session.getHangoutUrl());
-						}
-					}, this));
-				}
-			} else {
-				logger.warn("request for unknown session id: " + req.params.id);
-				res.status(404);
-				res.send();
-			}
-		
-		}, this));
-
-		//---------------------------------------------------------//
-		//						PERMALINKS 						   //
-		//---------------------------------------------------------//
-
-		this.express.get("/h/", _.bind(function(req, res) {
-			res.render('permalink-intro.ejs');
-		}, this));
-
-		this.express.get("/h/admin/:code/:key", _.bind(function(req, res) {
-			var session = this.permalinkSessions.find(function(s) {
-				return s.get("shortCode")===req.params.code;
-			});
-
-			if(_.isUndefined(session)) {
-				logger.warn("Request for /h/admin/:code/:key with unknown session code: " + req.params.code);
-				res.status(404);
-				res.send();
-				return;
-			}
-
-			if(req.params.key===session.get("creationKey")) {
-				// now render the normal permalink view, but with the admin interface showing.
-				res.render('permalink.ejs', {showAdmin: true, users:this.users, session:session });
-			} else {
-				logger.warn("Attempt to load /h/admin/:code/:key with invalid key for this session: " + req.params.key);
-				res.status(403);
-				res.send();
-				return;
-			}
-
-		}, this));
-
-		this.express.get("/h/:code", _.bind(function(req, res) {
-			logger.debug("GET /h/" +req.params.code + ": " + JSON.stringify(req.body))
-			// okay, this is the permalink part of the site. if this key exists already,
-			// then render an appropriate template immediately. if we don't have a 
-			// session that matches this code, then create one and then render
-			// the page.
-
-			// validate shortcodes here. 
-			var re = /^[A-Za-z0-9-_.+]*$/;
-			if(!re.test(req.params.code)) {
-				logger.warn("GET /h/" + req.params.code + " is not a valid hangout permalink");
-				res.status(400);
-				res.send();
-				return;
-			}
-
-
-			var session = this.permalinkSessions.find(function(s) {
-				return s.get("shortCode")===req.params.code;
-			});
-
-			if(_.isUndefined(session)) {
-				logger.debug("No session found for shortcode: '" + req.params.code + "', creating a new one.");
-				session = new models.ServerSession();
-
-				session.set("isPermalinkSession", true);
-
-				// use the specified code for the new session.
-				session.set("shortCode", req.params.code);
-				this.permalinkSessions.add(session);
-				session.generateCreationKey();
-				session.set("first-load", true);
-				session.save();
-
-				// now redirect them to the admin page for this session.
-				logger.info("Redirecting to admin page for a new permalink session code.");
-				res.redirect("/h/admin/" + req.params.code + "/" + session.get("creationKey"));
-				return;
-			}
-
-			// the problem with this is that we don't actually have all users in the
-			// hangout in our list of users. That only includes people who have logged
-			// in here. Not sure what to do about this. We'll either have to force
-			// people to google log in when they land on the page, OR we're
-			// going to have to have the participant information sent from the
-			// hangout app instead of just the ids involved.
-
-			res.render('permalink.ejs', {showAdmin: false, users:this.users, session:session});
-
-			// after rendering, drop the first-load 
-			if(session.get("first-load")) {
-				session.set("first-load", false);
-				session.save();
-			}
-		}, this));
-		
-		this.express.post("/h/admin/:code", _.bind(function(req, res) {
-			logger.info("POST /h/admin/"+ req.params.code + ": " + JSON.stringify(req.body));
-			if(!("creationKey" in req.body)) {
-				res.status(400);
-				res.send();
-				return;
-			}
-
-			// otherwise, if creationKey is present, check it against the specified session.
-			var session = this.permalinkSessions.find(function(s) {
-				return s.get("shortCode")==req.params.code;
-			});
-
-			if(_.isUndefined(session)) {
-				logger.warn("sess:unknown (set title/desc)" + JSON.stringify(req.body));
-				res.status(404);
-				res.send();
-				return;
-			}
-
-			if(req.body.creationKey===session.get("creationKey")) {
-				session.set("title", req.body.title);
-				session.set("description", req.body.description);
-				session.save();
-
-				logger.debug("updating session with params: " + JSON.stringify(req.body));
-
-				res.redirect("/h/" + req.params.code);
-			} else {
-				logger.warn("POST to /h/admin/:code with invaid creationKey.");
-				res.status(403);
-				res.send();
-				return;
-			}
-		}, this));
-
-		// this endpoint manually stops a shortcode session.
-		// we seem to occasionally get sessions that are broken and stay open when
-		// they're supposed to be closed. this lets us fix that issue.
-		// this checks global admin status, not per-shortcode admin status.
-		// we could at some point add this in to the permalink admin page, but I don't
-		// think people actually go back to that.
-		this.express.post("/h/:code/stop", ensureAdmin, _.bind(function(req, res) {
-			var session = this.permalinkSessions.find(function(s) {
-				return s.get("shortCode")==req.params.code;
-			});
-
-			if(_.isUndefined(session)) {
-				logger.warn("sess:unknown (stop)" + JSON.stringify(req.body));
-				res.status(404);
-				res.send();
-				return;
-			}
-
-			// this will cascasde to trigger hangout-stopped, since we're hard-triggering a stop.
-			session.set("hangoutConnected", false);
-			res.redirect("/admin");
-		}, this));
-
-
-		// all messages from the hangout app running in each of the active hangouts
-		// go to this endpoint. 
-		// TODO verify that this is using session keys, not sessionids (otherwise it would
-		// be super easy to spoof)
-		// TODO think about whether we want more security here. the right thing
-		// to do would be to require some sort of handshake on election so the keys
-		// for posting hangout messages aren't the same as the ones public to all
-		this.express.post("/session/hangout/:id", _.bind(function(req, res) {
-			logger.debug("POST /session/hangout/" + req.params.id + ":" + req.body.type)
-			// TODO need to switch this over to searching through session-keys in the events' domains using _.find
-			if(!("id" in req.params)) {
-				res.status(404);
-				res.send();
-				return;
-			}
-
-			var session = getSession(req.params.id, this.events, this.permalinkSessions);
-			
-
-			if(_.isUndefined(session)) {
-				logger.warn("session:unknown " + JSON.stringify(req.body) + " for key " + req.params.id);
-				res.status(400);
-				res.send();
-				return;
-			}
-
-			// make sure a type is specified
-			if(!("type" in req.body)) {
-				res.status(400)
-				res.send();
-				return;
-			}
-
-			// STOP DOING THIS it's causing major problems
-			// any message to a non-hangout-connected session should make it 
-			// be connected.
-			// if(!session.get("hangoutConnected")) {
-			// 	session.set("hangoutConnected", true);
-			// }
-
-			switch(req.body.type) {
-				// in the hangout-farming situation, this behavior of the app is basically vestigal.
-				// the server already knows what the url should be, and auto-assigns it before the
-				// hangout actually loads. But if we're not farming, this is critical, because the
-				// first loader needs to set the actual hangout url.
-				//
-				// this request is called for every person who loads a hangot. only the first one
-				// really has any functional impact, though. subsequent loads will ignore the
-				// setHangoutUrl piece because the hangout already has a url.
-				case "loaded":
-					if(session && "url" in req.body) {
-						logger.info("session:" + session.id + ":loaded\tparticipant:" + JSON.stringify(req.body.participant) + "\tparticipants: " + JSON.stringify(req.body.participants) + "\tkey: " + req.params.id + "\turl: " + req.body.url);
-
-						// get the post data; we're expecting the url to be in the payload.
-						var url = req.body.url;
-						logger.info("loaded url: " + url + " (url set in session: " + session.getHangoutUrl() + ")");
-
-						if(!session.get("hangoutConnected")) {
-							logger.info("first load of session, starting it up!");
-							session.set("hangoutConnected", true);
-						}
-
-						// set the start time, but only if it hasn't been set yet.
-						if(_.isNull(session.get("hangout-start-time")) || _.isUndefined(session.get("hangout-start-time"))) {
-							session.set("hangout-start-time", req.body.startTime);
-							session.save();
-						}
-
-						// the session will ignore this if it already has a url.
-						var fullURL = url + generateSessionHangoutGDParam(session, this.options);
-						// logger.debug("(trying to) set hangout url to: " + fullURL);
-						session.setHangoutUrl(fullURL);
-
-
-						res.status(200);
-						res.send();
-					} else {
-						logger.warn("request for unknown session id: " + req.params.id + " or missing payload: " + JSON.stringify(req.body));
-						res.status(404);
-						res.send();
-					}
-
-					break;
-
-				// sent any time someone joins or leaves a hangout. contains the full
-				// participant list every time.
-				case "participants":
-					// update the current participant list for this session. 
-					if(session && "participants" in req.body) {
-
-						// we need to look and see if we have this user id in our this.users
-						// list. if we don't, we need to keep track of them somehow. not
-						// sure exactly where to put this just yet.
-						var participantIds = _.map(req.body.participants, function(participant) {
-							return participant.person.id;
-						});
-
-						// TODO start checking to see if we have all these participants in our user list
-						// and if their id is not tracked in users, add them in. This will help us rendering
-						// their pictures elsewhere in the app without much trouble.
-						_.each(req.body.participants, _.bind(function(participant) {
-							if(_.isUndefined(this.users.get(participant.person.id))) {
-								logger.debug("creating new user object");
-
-								var newUserAttrs = {displayName:participant.person.displayName,
-									id:participant.person.id};
-
-								if(participant.person.image) {
-									newUserAttrs["picture"] = participant.person.image.url;
-								}
-
-								var newUser = new models.ServerUser(newUserAttrs);
-								newUser.set("createdViaHangout", true);
-								this.users.add(newUser);
-								newUser.save();
-							} else {
-								// TODO perhaps add a flag that this user was seen in a permalink
-								// based hangout? 
-							}
-						}, this));
-
-						logger.info("session:" + session.id + ":participants\t" + JSON.stringify(participantIds));
-
-						session.setConnectedParticipantIds(participantIds);
-
-						// count this as a heartbeat, since it represents active hangout activity. Useful since
-						// the first heartbeat isn't for 5 seconds, and in some situations there might be an 
-						// extant heartbeat-check interval running that could fire before this new participant
-						// picks up heartbeat responsibilities.
-						session.heartbeat();
-					} else {
-						logger.warn("Received a request for participants missing appropriate session key or participants field.");
-						res.status(404);
-						res.send();
-					}
-					break;
-				// hangouts send heartbeats every 5 seconds so we can tell that the
-				// hangout is still running. this is because there is not a reliable
-				// "closing hangout" message, so we have to infer it from heartbeats
-				// disappearing.
-				case "heartbeat":
-					logger.debug("session:" + session.id + ":heartbeat\tfrom:" + req.body.from + "\tparticipants: " + JSON.stringify(req.body.participants) + "\turl: " + req.body.url + "\tstartTime: " + req.body.startTime + "\tfromLeader: " + req.body.fromLeader);
-					var err = session.heartbeat(req.body.participants, req.body.url + generateSessionHangoutGDParam(session, this.options), req.body.startTime);
-
-					if(err) {
-						logger.error("Sending fail to newer hangout session!");
-
-						res.status(200);
-						res.send("FAIL");
-
-						// drop out to avoid hitting later status/send calls.
-						return;
-					}
-
-					break;
-				default: 
-					logger.warn("Got unknown hangout post: " + JSON.stringify(req.body));
-					break;
-			}
-			// after whatever manipulation we've done, save the session.
-			session.save();
-
-
-			// Close out the requests successfully, assuming that if anything else were wrong
-			// they would have been closed out and the method returned earlier in execution.
-			res.status(200);
-			res.send();
-		}, this));
-
-		this.express.post("/subscribe", _.bind(function(req, res) {
-			logger.debug("POST /subscribe");
-
-			// save subscription emails
-			if("email" in req.body && req.body.email.length > 5 && req.body.email.length < 100) {
-				this.redis.lpush("global:subscriptions", req.body.email);
-				logger.info("subscribed email: " + req.body.email);
-				res.status(200);
-				res.send();
-			} else {
-				res.status(400);
-				res.send();
-			}
-		}, this));
-
-		this.express.get("/admin", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			logger.info("GET /admin");
-
-			var sortedPermalinkSesssions = this.permalinkSessions.sortBy(function(s) {
-				return s.get("user-seconds") * -1;
-			});
-
-			sortedPermalinkSesssions = _.sortBy(sortedPermalinkSesssions, function(s) {
-				return s.get("connectedParticipantIds").length * -1;
-			});
-
-			// now prepend all event sessions 
-			var sessions = _.flatten(this.events.map(function(event) {
-				if(event.isLive()) {
-					return event.get("sessions").toArray();
-				} else {
-					return [];
-				}
-			}));
-
-			var allSessions = sessions.concat(sortedPermalinkSesssions);
-
-			res.render('admin.ejs', {user:req.user, events:this.events, sessions:allSessions, event:undefined });
-		}, this));
-
-		this.express.get("/admin/event/new", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			logger.debug("GET /admin/event/new");
-			var event = this.events.get(req.params.id);
-
-			var context = {user:req.user, events:this.events, event:event, create:true};
-
-			res.render('admin-event.ejs', context);
-		}, this));
-
-		this.express.post("/admin/event/new", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			logger.debug("POST /admin/event/new " + JSON.stringify(req.body));
-
-			// make sure title and description are present, otherwise reject the request.
-			if(!("title" in req.body) || !("description" in req.body)) {
-				res.status(400);
-				res.send();
-				return;
-			}
-
-			var event = new models.ServerEvent({title:req.body.title, shortName:req.body.shortName, description:req.body.description,
-					welcomeMessage:req.body.welcomeMessage, organizer:req.body.organizer});
-
-			event.save();
-			this.events.add(event);
-
-			logger.info("Created a new event: " + JSON.stringify(event));
-
-			res.redirect("/admin");
-		}, this));
-
-		this.express.post("/admin/event/:id/start", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			var event = this.events.get(req.params.id);
-
-			if(_.isUndefined(event)) {
-				logger.warn("Attempt to stop unknown event id: " + req.params.id);
-				res.status(404);
-				res.send();
-				return;
-			};
-
-			var err = event.start();
-
-			if(err) {
-				res.status(500);
-				res.send(err);
-				return;
-			}
-
-			logger.info("Started event:" + req.params.id);
-
-			res.redirect("/admin/");
-		}, this));
-
-		this.express.post("/admin/event/:id/stop", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			var event = this.events.get(req.params.id);
-
-			if(_.isUndefined(event)) {
-				logger.warn("Attempt to start unknown event id: " + req.params.id);
-				res.status(404);
-				res.send();
-				return;
-			};
-
-			var err = event.stop();
-			if(err) {
-				res.status(500);
-				res.send(err);
-				return;
-			}
-
-			logger.info("Stopped event:" + req.params.id);
-
-			res.redirect("/admin/");
-		}, this));
-
-		this.express.get("/admin/event/:id", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			var event = this.events.get(req.params.id);
-
-			if(_.isUndefined(event)) {
-				logger.warn("Attempt to load unknown event id: " + req.params.id);
-				res.status(404);
-				res.send();
-				return;
-			};
-
-			res.render('admin-event.ejs', {user:req.user, events:this.events, event:event, _:_, loadApp:false, create:false})
-		}, this));
-
-
-		this.express.post("/admin/event/:id", ensureAuthenticated, ensureAdmin, _.bind(function(req, res) {
-			var event = this.events.get(req.params.id);
-
-			if(_.isUndefined(event)) {
-				logger.warn("Attempt to update unknown event id: " + req.params.id);
-				res.status(404);
-				res.send();
-				return;
-			};
-
-			var shouldBroadcast = false;
-
-			if(event.get("description")!=req.body.description) {
-				shouldBroadcast = true;
-			}
-
-			// now we need to update everything...
-			event.set("title", req.body.title);
-			event.set("shortName", req.body.shortName);
-			event.set("description", req.body.description);
-			event.set("welcomeMessage", req.body.welcomeMessage);
-			event.set("organizer", req.body.organizer);
-			event.set("blurDisabled", req.body.blurDisabled);
-			event.save();
-
-			logger.debug("new event attributes: " + JSON.stringify(event));
-
-			if(shouldBroadcast) {
-				event.broadcast("event-update", event.toJSON());
-			}
-
-			res.redirect("/admin/event/" + event.id);
-		}, this));
-
-		this.express.get("/")
-		
-		// hand off the express object so the hangout farming code can 
-		// set up their required listeners.
-		farming.init(this);
+        unhangoutRoutes.route(this.express, this.db, this.options);
+        permalinkRoutes.route(this.express, this.db, this.options);
+		farming.init(this.express, this.db, this.options);
 		
 		this.http.listen(process.env.PORT || this.options.PORT);
-
 		if(this.options.timeoutHttp) {
 			this.http.setTimeout(400);
 		}
@@ -1322,30 +258,10 @@ exports.UnhangoutServer.prototype = {
 			return;
 		}
 		logger.info("Stopping UnhangoutServer!");
-		
-		// this little bit of cleverness is disconnecting all the unauthenticated sockets
-		// in parallel, and then once they all return a "close" event, moving on with
-		// the shutdown process. The dance through types here is:
-		// 1. go from an Object that is socket.id -> socket to just a list of sockets (_.values)
-		//		also, merge in all the sock objects from users
-		// 2. convert each of those sockets into a function that disconnects that socket, and calls
-		//		the callback function when it's successful
-		// 3. put those resulting function references into a list of parallel functions to execute
-		async.parallel(_.map(_.union(_.values(this.unauthenticatedSockets), this.users.pluck("sock")), function(socket) {
-			// if the socket doesn't exist, just callback instantly
-			if(_.isNull(socket) || _.isUndefined(socket)) {
-				return function(callback) {
-					callback();
-				}
-			};
-
-
-			return function(callback) {
-				socket.on("close", callback);
-				socket.close()
-			};
-		}), _.bind(function(err, results) {
-			// this executes only after we've disconnected all the unauthenticated sockets.
+        this.socketManager.shutdown(_.bind(function(err, message) {
+            if (err) {
+                logger.error(err)
+            }
 			if(this.httpRedirect) {
 				this.httpRedirect.close();
 			}
@@ -1356,215 +272,22 @@ exports.UnhangoutServer.prototype = {
 				this.running = false;
 				this.emit("stopped");
 				}, this));
-			}, this));
+        }, this));
 	},
 	
 	destroy: function() {
 		this.express = null;
-		this.sockjs = null;
 		this.http = null;
+        this.socketManager = null;
 
 		this.httpRedirect = null;
 				
 		logger.info("destroyed");
 		this.emit("destroyed");
-	},
-	
-	initializeModelsFromRedis: function(done) {
-		// Okay, this looks scary but it's relatively simple.
-		// Basically, the loaders set up methods that we call
-		// with a simple JS object representing each of the
-		// objects of that type in redis. It simply needs to 
-		// construct matching objects. This drives the 
-		// crazy async engine that follows. To add a new type,
-		// just add a matching entry in loaders and follow
-		// the format.
-		
-		var loaders = {
-			"user/*":_.bind(function(callback, attrs, key) {
-				var newUser = new models.ServerUser(attrs);
-				// no need to save since we're pulling from the
-				// database to begin with.
-				this.users.add(newUser);
-				callback();
-			}, this),
-			
-			"event/?????":_.bind(function(callback, attrs, key) {
-				var newEvent = new models.ServerEvent(attrs);				
-				this.events.add(newEvent);
-				callback();
-			}, this),
-			
-			"event/*/sessions/*":_.bind(function(callback, attrs, key) {
-				var eventId = parseInt(key.split("/")[1]);
-
-				var event = this.events.get(eventId);
-				var newSession = new models.ServerSession(attrs);
-				event.addSession(newSession);
-				
-				callback();
-			}, this),
-
-			"session/permalink/*":_.bind(function(callback, attrs, key) {
-				var newSession = new models.ServerSession(attrs);
-
-				// force these to be true. This fixes a transient condition where some
-				// keys in the db didn't have this set and it defaults to false.dw
-				newSession.set("isPermalinkSession", true);
-
-				this.permalinkSessions.add(newSession);
-				callback();
-			}, this)
-		};
-		
-		// This mess is doing three things:
-		// 1) figuring out all the key names of all the objects of this type in redis
-		// 2) running mget to grab all those json strings at once
-		// 3) calling the loader callbacks with parsed versions of those JSON strings
-		//
-		// It seems worse than it is because of annoying async/map/bind wrappers, but
-		// that's just to get all the closures configured right.
-		async.series(_.map(_.pairs(loaders), _.bind(function(loader) {
-			return _.bind(function(callback) {
-				logger.info("loading " + loader[0]);
-				this.redis.keys(loader[0], _.bind(function(err, modelKeys) {
-					if(modelKeys.length==0) {
-						callback(err);
-						return;
-					}
-					this.redis.mget(modelKeys, _.bind(function(err, modelsJSON) {
-						async.parallel(_.map(modelsJSON, _.bind(function(modelJSON, index) {
-							var key = modelKeys[index];
-							return _.bind(function(callback) {
-								var attrs = JSON.parse(modelJSON);
-								loader[1](callback, attrs, key);
-							}, this);
-						}, this)), function(err, result) {
-							callback();
-						});
-					}, this));
-				}, this));
-			}, this);
-		}, this)), function(err, results) {
-			logger.info("Done loading models.");
-			done();
-		});
 	}
 }
 
-// a simple express middleware to enforce authentication. 
-function ensureAuthenticated(req, res, next) {
-  if (req.isAuthenticated()) { return next(); }
-  req.session["post-auth-path"] = req.path;
-  res.redirect('/auth/google');
-}
-
-function ensureAdmin(req, res, next) {
-    logger.info("admin check: " + req.user.get("displayName"));
-    if(req.user.isAdmin()) {
-        next();
-    } else {
-        res.redirect("/");
-    }
-}
-
-// an express middleware that we apply to the entire site.
-// for some reason, that works better than applying it just to the
-// resources that actually need to be accessed cross domain.
-var allowCrossDomain = function(domain) {
-	return function(req, res, next) {
-	    res.header('Access-Control-Allow-Origin', domain);
-	    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
-	    res.header('Access-Control-Allow-Headers', 'Content-Type');
-
-	    next();
-	}
-}
 
 // Mix in the node events structures so we have on/emit available on the server.
 // This is helpful for testing and various other sorts of indirection.
 _.extend(exports.UnhangoutServer.prototype, EventEmitter.prototype);
-
-// helper methods to do repetetive protocol-related work of extracting
-// sessions from messages and dealing with errors.
-function getSessionFromMessage(message, user, event, type) {
-	var session = event.get("sessions").get(message.args.id);
-	
-	if(_.isNull(session) || _.isUndefined(session)) {
-		user.writeErr(type, "session is not in event list");
-		return new Error("session is not in event list");
-	} else {
-		return session;
-	}
-}
-
-// like above, but for events.
-function getEvent(message, user, type) {
-	var event = user.get("curEvent");
-	if(_.isNull(event) || _.isUndefined(event)) {
-		user.writeErr(type, "user has no event");
-		return new Error("user has no event");
-	} else {
-		return event;
-	}
-}
-
-// I really want these to be class methods on a socket, but I'll be damned if I can
-// figure out how to do it.
-function writeObj(conn, type, args) {
-	conn.write(JSON.stringify({type:type, args:args}));
-}
-
-function writeErr(conn, msgType, errorMessage) {
-	if(!_.isUndefined(errorMessage) && !_.isNull(errorMessage)) {
-		conn.write(JSON.stringify({type:msgType+"-err", args:{message:errorMessage}}));
-	} else {
-		conn.write(JSON.stringify({type:msgType+"-err"}));
-	}
-}
-
-function writeAck(conn, msgType) {
-	conn.write(JSON.stringify({type:msgType+"-ack"}));
-}
-
-function getSession(sessionId, events, permalinkSessions) {
-
-	// logger.debug("sessionId: " + sessionId);
-	// this is a bit silly, but we don't maintain a separate dedicated list of sessions,
-	// and there's no easy way to map back from a session id to that session's event.
-	// so, create a temporary list of sessions to look up against.
-	var sessions = _.flatten(events.map(function(event) {
-		return event.get("sessions").toArray();
-	}));
-	
-	// add in the permalink sessions.
-	sessions = _.union(sessions, permalinkSessions.toArray());
-	var session = _.find(sessions, function(session) {
-
-		if(_.isNull(session.get("session-key")) || _.isUndefined(session.get("session-key"))) {
-			// logger.debug("ignoring session without a session key");
-			return false;
-		} else {
-			// logger.debug("id: " + session.id + "; key: " + session.get("session-key") + " title: " + session.get("title"));
-			// logger.debug(".id===id: " + (session.id===parseInt(sessionId) + "") + " : session-key===id: " + ("" + (session.get("session-key")===sessionId)));
-		}
-
-		// TODO try just doing the second clause here. why does the first one even exist?
-		// return session.id===parseInt(sessionId) || session.get("session-key")===sessionId;
-		return session.get("session-key")===sessionId;
-	});
-
-	// logger.debug("returning session: " + JSON.stringify(session));
-	
-	return session;
-}
-
-function generateSessionHangoutGDParam(session, options) {
-	// logger.debug("generating url for session: " + JSON.stringify(session));
-
-	// replace : with | in any free-text field like title and description
-	return "?gid="+options.HANGOUT_APP_ID + 
-		"&gd=" + options.HOST + ":" + options.PORT + ":" + 
-		session.get("session-key") +':'+ encodeURIComponent(session.get('title').replace(":", "|")) +':'+ encodeURIComponent(session.get("isPermalinkSession") ? session.get('description').replace(":", "|") : "none") +':'+
-		session.get('shortCode') + ':' + session.get("isPermalinkSession") + ':' + encodeURIComponent(session.collection.event ? session.collection.event.get("title").replace(":", "|") : "none");
-}

--- a/lib/unhangout-sockets.js
+++ b/lib/unhangout-sockets.js
@@ -1,0 +1,412 @@
+var sockjs_lib = require("sockjs"),
+    events = require("events"),
+    _ = require("underscore")
+    models = require("./server-models"),
+    logger = require("./logging").getLogger();
+
+// helper methods to do repetetive protocol-related work of extracting
+// sessions from messages and dealing with errors.
+function getSessionFromMessage(message, user, event, type) {
+    var session = event.get("sessions").get(message.args.id);
+    
+    if(_.isNull(session) || _.isUndefined(session)) {
+        user.writeErr(type, "session is not in event list");
+        return new Error("session is not in event list");
+    } else {
+        return session;
+    }
+}
+
+// like above, but for events.
+function getEvent(message, user, type) {
+    var event = user.get("curEvent");
+    if(_.isNull(event) || _.isUndefined(event)) {
+        user.writeErr(type, "user has no event");
+        return new Error("user has no event");
+    } else {
+        return event;
+    }
+}
+
+// I really want these to be class methods on a socket, but I'll be damned if I can
+// figure out how to do it.
+function writeErr(conn, msgType, errorMessage) {
+    if(!_.isUndefined(errorMessage) && !_.isNull(errorMessage)) {
+        conn.write(JSON.stringify({type:msgType+"-err", args:{message:errorMessage}}));
+    } else {
+        conn.write(JSON.stringify({type:msgType+"-err"}));
+    }
+}
+
+function writeAck(conn, msgType) {
+    conn.write(JSON.stringify({type:msgType+"-ack"}));
+}
+
+/*
+    Main export: manager for sockets.
+*/
+function UnhangoutSocketManager(httpServer, db, options) {
+    this.httpServer = httpServer;
+    this.db = db;
+    this.options = options;
+    _.bindAll(this, "init", "shutdown");
+    this.unauthenticatedSockets = {};
+}
+_.extend(UnhangoutSocketManager.prototype, events.EventEmitter, {
+    init: function() {
+		// create a sockjs server, and shim their default built in logging behavior
+		// into our standard logger.
+		this.sockjs = sockjs_lib.createServer({
+			"log": function(severity, message) {
+				logger.log("debug", severity + ": " + message);
+			},
+			"disconnect_delay": this.options.disconnect_delay
+		});
+		
+		// when we get a new sockjs connection, register it and set up 
+		this.sockjs.on('connection', _.bind(function(conn) {			
+		    logger.info('connection' + conn);
+					
+			// flag the connection as unauthenticated until we get an authentication message.
+			conn.authenticated = false;
+			
+			// this can be helpful for debugging purposes, to have separate distinct
+			// connection ids.
+			conn.id = Math.floor(Math.random()*10000000);
+			
+			// put this connection in the unauthenticated list
+			this.unauthenticatedSockets[conn.id] = conn;
+		
+			// when the connection closes, make sure the user object 
+			// hears about it.
+		    conn.once('close', _.bind(function() {
+				if(conn.authenticated) {
+					logger.info("closing id: " + conn.id);
+					conn.user.disconnect();
+				} else {
+					// if they never authenticated, just clean out the unauthenticated
+					// sockets list.
+					delete this.unauthenticatedSockets[conn.id];
+				}
+		    }, this));
+			
+			// this is where the primary protocol specification lives. whenever
+			// we get a message FROM a client, this method is called. Messages
+			// arive as raw strings.
+
+		    conn.on('data', _.bind(function(string) {
+
+				// TODO wrap this in error handling
+
+				// reject messages that don't JSON parse
+				var message;
+				try {
+					message = JSON.parse(string);
+				} catch (e) {
+					logger.warn("Error parsing message from client: " + string);
+					return;
+				}
+
+				// reject messages that don't have a "type" field
+				if(!("type" in message)) {
+					logger.warn("Received message without 'type' key: " + string);
+					return;
+				}
+				var user;
+
+				// switch on the message type
+				//
+				// Each message type has some similar components.
+				// First, we check for relevant arguments that we need to have
+				// to execute the command. Then we assemble the relevant objects
+				// for the operation, ie the user object and session object if
+				// a user is trying to sign up for a session. Finally,
+				// we execute the action on the object, eg call "attend" on the
+				// session with the specified user object. 
+				//
+				// We try whenever possible to return descriptive error messages
+				// if something about the arguments is wrong. 
+				switch(message.type) {
+					case "auth":
+						// expecting: "id" and "key"
+						if("id" in message.args && "key" in message.args) {
+							
+							user = this.db.users.get(message.args.id);
+							
+							if(_.isUndefined(user)) {
+								logger.warn("User presented unrecognized id: " + message.args.id);
+								writeErr(conn, "auth");
+								return;
+							}
+							
+							// this is the bulk of the command here; we're checking
+							// that the key presented in the message is the same as
+							// by the user in .getSockKey() - which is called during
+							// page load by the templating engine. That sets the key
+							// in the server-side user object, and then we check that
+							// it matches here. 
+
+							if(user.validateSockKey(message.args.key)) {
+								logger.info("AUTHENTICATED sock " + conn.id + " to user " + user.id);
+								conn.authenticated = true;
+								// TODO send a message to the client acknowledging.
+								
+								// since the socket is now authenticated, remove it
+								// from the unauthenticated pool.
+								delete this.unauthenticatedSockets[conn.id];
+								
+								user.setSock(conn);
+								conn.user = user;
+								
+								writeAck(conn, "auth");
+							} else {
+								logger.warn("Invalid key presented for user " + user.id);
+								writeErr(conn, "auth");
+							}
+							
+						} else {
+							logger.warn("Missing 'id' or 'key' in AUTH message payload.");
+							writeErr(conn, "auth");
+							return;
+						}
+						break;
+					case "join":
+						// mark which event page they're on
+						user = conn.user;
+						
+						// check arguments
+						if(!("id" in message.args)) {
+							user.writeErr("join");
+							return;
+						}
+						
+						// confirm the event to be joined exists
+						// the getEvent wrapper abstracts this process,
+						// including sending error messages to the client
+						// if the event doesn't exist (as specified in
+						// msg.args)
+						var event = this.db.events.get(message.args.id);
+						if(_.isUndefined(event)) {
+							user.write("join-err", "Invalid event id.");
+							return;
+						}
+
+						// if(event instanceof Error) return;
+												
+						// join it!
+						// this will generate the relevant broadcast messages
+						// to tell other users that someone has joined. 
+						event.userConnected(user);
+						user.writeAck("join");
+						break;
+					case "create-session":
+						user = conn.user;
+
+						// enforce admin-ness of the user who is trying to 
+						// create a session. 
+						if(!user.isAdmin()) {
+							logger.warn("User " + user.id + " tried to create-session, but is not an admin.");
+							user.writeErr("create-session");
+							return;
+						}
+						
+						var event = getEvent(message, user, "create-session");
+						if(event instanceof Error) return;
+
+						if("title" in message.args && "description" in message.args) {
+							// make the new session!
+							var newSession = new models.ServerSession({"title":message.args.title, "description":message.args.description});
+							newSession.save();
+
+							// once the id has been set in the save process,
+							// add the session to the event.
+							logger.debug("pre bind");
+							newSession.on("change:id", _.once(function() {
+								// the broadcast happens in addSession, as does the event save.
+								event.addSession(newSession);
+							}));
+
+							user.writeAck("create-session");
+						} else {
+							user.writeErr("create-session", "Missing name or description in arguments.");
+						}
+						
+						break;
+					case "chat":
+						user = conn.user;
+						
+						if(!("text" in message.args)) {
+							user.writeErr("chat", "missing text in chat message");
+							return;
+						}
+						
+						var event = getEvent(message, user, "chat");
+						if(event instanceof Error) return;
+												
+						try {
+							event.sendChatFromUser(message.args.text, user)							;
+							user.writeAck("chat");
+						} catch (e) {
+							user.writeErr("chat");
+						}
+						
+						break;
+
+					case "delete":
+						user = conn.user;
+						if(!user.isAdmin()) {
+							logger.warn("User " + user.id + " tried to delete, but is not an admin.");
+							user.writeErr("delete");
+							return;
+						}
+						
+						var event = getEvent(message, user, "delete");
+						if(event instanceof Error) return;
+						
+						var session = getSessionFromMessage(message, user, event, "delete");
+						if(session instanceof Error) return;
+						
+						session.destroy();
+						event.removeSession(session);
+						logger.info("Removed session: " + session.id + " from event " + event.id);
+						user.writeAck("delete");
+						event.save();
+						break;
+
+					case "open-sessions":
+						user = conn.user;
+						if(!user.isAdmin()) {
+							logger.warn("User " + user.id + " tried to open sessions, but is not an admin.");
+							user.writeErr("open-sessions");
+							return;
+						}
+
+						var event = getEvent(message, user, "open-sessions");
+						if(event instanceof Error) return;
+
+						event.openSessions();
+
+						user.writeAck("open-sessions");
+						event.save();
+						break;
+
+					case "close-sessions":
+						user = conn.user;
+						if(!user.isAdmin()) {
+							logger.warn("User " + user.id + " tried to open sessions, but is not an admin.");
+							user.writeErr("close-sessions");
+							return;
+						}
+
+						var event = getEvent(message, user, "close-sessions");
+						if(event instanceof Error) return;
+
+						event.closeSessions();
+						user.writeAck("close-sessions");
+
+						event.save();
+						break;
+
+					// sets the current video embed. An empty string is considered
+					// no embed. 
+					case "embed":
+						user = conn.user;
+						if(!user.isAdmin()) {
+							logger.warn("User " + user.id + " tried to set embed, but is not an admin.");
+							user.writeErr("embed");
+							return;
+						}
+
+						var event = getEvent(message, user, "embed");
+						if(event instanceof Error) return;
+												
+						if("ytId" in message.args) {
+							event.setEmbed(message.args.ytId);
+							user.writeAck("embed");
+							event.save();
+						} else {
+							user.writeErr("embed");
+						}
+
+						break;
+
+					// blur and focus are just mini state change events on
+					// the user object. they help users track who has the
+					// lobby window as their fore-ground window, and who has
+					// switched to some other window (probably a hangout)
+					// nothing fancy here, just flipping a bit in the user
+					// object.
+					case "blur":
+						 user = conn.user;
+
+						if(!("id" in message.args)) {
+							user.writeErr("blur", "missing id in args");
+							return;
+						}
+						
+						var event = getEvent(message, user, "blur");
+						if(event instanceof Error) return;
+						
+						user.setBlurred(true);
+						
+						break;
+
+					case "focus":
+						 user = conn.user;
+
+						if(!("id" in message.args)) {
+							user.writeErr("focus", "missing id in args");
+							return;
+						}
+						
+						var event = getEvent(message, user, "focus");
+						if(event instanceof Error) return;
+						
+						user.setBlurred(false);
+
+						break;
+
+					default:
+						logger.warn("Server does not handle '" + message.type + "' type events.");
+						break;
+				}
+
+				logger.info("message:" + user.id + ":" + message.type + "  " + JSON.stringify(message.args));
+
+		    }, this));
+		}, this));
+		
+		logger.info("sockjs server created");
+		
+		// sockjs negotiates its startup process over http. so, we need to
+		// tell it where in our routing it should put its endpoints.
+		this.sockjs.installHandlers(this.httpServer, {prefix:'/sock'});
+		
+		logger.info("socket handlers installed");
+    },
+    shutdown: function(callback) {
+        this.sockjs.removeAllListeners();
+        // this little bit of cleverness is disconnecting all the unauthenticated sockets
+        // in parallel, and then once they all return a "close" event, moving on with
+        // the shutdown process. The dance through types here is:
+        // 1. go from an Object that is socket.id -> socket to just a list of sockets (_.values)
+        //      also, merge in all the sock objects from users
+        // 2. convert each of those sockets into a function that disconnects that socket, and calls
+        //      the callback function when it's successful
+        // 3. put those resulting function references into a list of parallel functions to execute
+        async.parallel(_.map(_.union(_.values(this.unauthenticatedSockets), this.db.users.pluck("sock")), function(socket) {
+            // if the socket doesn't exist, just callback instantly
+            if(_.isNull(socket) || _.isUndefined(socket)) {
+                return function(callback) {
+                    callback();
+                }
+            };
+            return function(callback) {
+                socket.on("close", callback);
+                socket.close()
+            };
+        }), callback);
+    }
+});
+
+module.exports.UnhangoutSocketManager = UnhangoutSocketManager;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,66 @@
+var _ = require("underscore"),
+    logger = require("./logging").getLogger();
+
+module.exports = {
+    // a simple express middleware to enforce authentication. 
+    ensureAuthenticated: function (req, res, next) {
+        if (req.isAuthenticated()) { return next(); }
+        req.session["post-auth-path"] = req.path;
+        res.redirect('/auth/google');
+    },
+
+    ensureAdmin: function (req, res, next) {
+        logger.info("admin check: " + req.user.get("displayName"));
+        if(req.user.isAdmin()) {
+            next();
+        } else {
+            res.redirect("/");
+        }
+    },
+    // an express middleware that we apply to the entire site.
+    // for some reason, that works better than applying it just to the
+    // resources that actually need to be accessed cross domain.
+    allowCrossDomain: function(domain) {
+        return function(req, res, next) {
+            res.header('Access-Control-Allow-Origin', domain);
+            res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+            res.header('Access-Control-Allow-Headers', 'Content-Type');
+
+            next();
+        }
+    },
+    getSession: function(sessionId, events, permalinkSessions) {
+
+        // logger.debug("sessionId: " + sessionId);
+        // this is a bit silly, but we don't maintain a separate dedicated list of sessions,
+        // and there's no easy way to map back from a session id to that session's event.
+        // so, create a temporary list of sessions to look up against.
+        var sessions = _.flatten(events.map(function(event) {
+            return event.get("sessions").toArray();
+        }));
+        
+        // add in the permalink sessions.
+        sessions = _.union(sessions, permalinkSessions.toArray());
+        var session = _.find(sessions, function(session) {
+
+            if(_.isNull(session.get("session-key")) || _.isUndefined(session.get("session-key"))) {
+                // logger.debug("ignoring session without a session key");
+                return false;
+            } else {
+                // logger.debug("id: " + session.id + "; key: " + session.get("session-key") + " title: " + session.get("title"));
+                // logger.debug(".id===id: " + (session.id===parseInt(sessionId) + "") + " : session-key===id: " + ("" + (session.get("session-key")===sessionId)));
+            }
+
+            // TODO try just doing the second clause here. why does the first one even exist?
+            // return session.id===parseInt(sessionId) || session.get("session-key")===sessionId;
+            return session.get("session-key")===sessionId;
+        });
+
+        // logger.debug("returning session: " + JSON.stringify(session));
+        
+        return session;
+    }
+}
+
+
+

--- a/test/common.js
+++ b/test/common.js
@@ -91,7 +91,7 @@ exports.standardShutdown = function(done, s) {
 // already being inited with users.
 exports.authedSock = function(userKey, room, callback) {
     var newSock = sock_client.create("http://localhost:7777/sock");
-    var user = exports.server.users.findWhere({"sock-key": userKey});
+    var user = exports.server.db.users.findWhere({"sock-key": userKey});
     var onData = function(message) {
         var msg = JSON.parse(message);
         if (msg.type === "auth-ack") {

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -35,7 +35,7 @@ describe('HTTP ADMIN API', function() {
 				.redirects(0)
 				.end(function(res) {
 					res.status.should.equal(302);
-                    var evt = common.server.events.at(common.server.events.length-1);
+                    var evt = common.server.db.events.at(common.server.db.events.length-1);
                     evt.get("title").should.equal("Test Event");
                     evt.get("description").should.equal("Description of the test event.");
 
@@ -96,7 +96,7 @@ describe('HTTP ADMIN API', function() {
 				.redirects(0)
 				.end(function(res) {
 					res.status.should.equal(302);
-                    var evt = common.server.events.at(0);
+                    var evt = common.server.db.events.at(0);
                     evt.get("title").should.equal("Test Event");
                     evt.get("description").should.equal("Description of the test event.");
 					done();

--- a/test/test.chat.selenium.js
+++ b/test/test.chat.selenium.js
@@ -11,7 +11,7 @@ var evt = null;
 
 describe("CHAT WINDOW", function() {
     if (process.env.SKIP_SELENIUM_TESTS) { return; }
-    this.timeout(120000); // Extra long timeout for selenium :(
+    this.timeout(40000); // Extra long timeout for selenium :(
 
     before(function(done) {
         async.series([
@@ -23,7 +23,7 @@ describe("CHAT WINDOW", function() {
             },
             function(done) {
                 common.standardSetup(function() {
-                    evt = common.server.events.at(0);
+                    evt = common.server.db.events.at(0);
                     evt.start();
                     done();
                 });


### PR DESCRIPTION
This is a MAJOR refactor -- it touches basically every part of lib/ and
most of test/.  Split lib/unhangout-server.js into 7 files:
- lib/unhangout-server.js: http, express, middleware, and lifecycle
- lib/unhangout-db.js: Redis, backbone collections
- lib/unhangout-sockets.js: Sockjs server and client management, and
  routing socket messages. (Does not incorporate room-manager yet).
- lib/unhangout-routes.js: unhangout HTTP routes (via express)
- lib/permalink-routes.js: permalink HTTP routes (via express)
- lib/redirect-https.js: HTTP redirect server
- lib/utils.js: common utilities and middleware.

The unhangout-server object no longer has references to redis, events,
users, and permalinkSessions -- instead, it has a reference to an
UnhangoutDb object (server.db) which holds those.

Given the magnitude of this changeset, it's worth some thorough manual
testing before pulling.  It passes the test suite, but coverage could be
better.
