### PR TITLE
Refactor DB loading for deterministic order

### DIFF
--- a/lib/unhangout-db.js
+++ b/lib/unhangout-db.js
@@ -57,76 +57,95 @@ _.extend(UnhangoutDb.prototype, events.EventEmitter.prototype, {
         // Okay, this looks scary but it's relatively simple.  Basically, the
         // loaders set up methods that we call with a simple JS object
         // representing each of the objects of that type in redis. It simply
-        // needs to construct matching objects. This drives the crazy async
-        // engine that follows. To add a new type, just add a matching entry in
-        // loaders and follow the format.
-        
-        var loaders = {
-            "user/*":_.bind(function(callback, attrs, key) {
+        // needs to construct matching objects.  To add a new type, just add a
+        // matching entry in loaders and follow the format.
+        var that = this;
+        var loaders = [
+            ["user/*", function(callback, attrs, key) {
                 var newUser = new models.ServerUser(attrs);
                 // no need to save since we're pulling from the
                 // database to begin with.
-                this.users.add(newUser);
+                that.users.add(newUser);
                 callback();
-            }, this),
-            
-            "event/?????":_.bind(function(callback, attrs, key) {
+            }],
+
+            ["event/?????", function(callback, attrs, key) {
                 var newEvent = new models.ServerEvent(attrs);               
-                this.events.add(newEvent);
+                that.events.add(newEvent);
                 callback();
-            }, this),
-            
-            "event/*/sessions/*":_.bind(function(callback, attrs, key) {
+            }],
+
+            ["event/*/sessions/*", function(callback, attrs, key) {
                 var eventId = parseInt(key.split("/")[1]);
 
-                var event = this.events.get(eventId);
+                var event = that.events.get(eventId);
                 var newSession = new models.ServerSession(attrs);
                 event.addSession(newSession);
                 
                 callback();
-            }, this),
+            }],
 
-            "session/permalink/*":_.bind(function(callback, attrs, key) {
+            ["session/permalink/*", function(callback, attrs, key) {
                 var newSession = new models.ServerSession(attrs);
 
                 // force these to be true. This fixes a transient condition where some
                 // keys in the db didn't have this set and it defaults to false.dw
                 newSession.set("isPermalinkSession", true);
 
-                this.permalinkSessions.add(newSession);
+                that.permalinkSessions.add(newSession);
                 callback();
-            }, this)
-        };
-        
+            }]
+        ];
         // This mess is doing three things:
         // 1) figuring out all the key names of all the objects of this type in redis
         // 2) running mget to grab all those json strings at once
         // 3) calling the loader callbacks with parsed versions of those JSON strings
-        //
-        // It seems worse than it is because of annoying async/map/bind wrappers, but
-        // that's just to get all the closures configured right.
-        async.series(_.map(_.pairs(loaders), _.bind(function(loader) {
-            return _.bind(function(callback) {
-                logger.info("loading " + loader[0]);
-                this.redis.keys(loader[0], _.bind(function(err, modelKeys) {
-                    if(modelKeys.length==0) {
-                        callback(err);
-                        return;
-                    }
-                    this.redis.mget(modelKeys, _.bind(function(err, modelsJSON) {
-                        async.parallel(_.map(modelsJSON, _.bind(function(modelJSON, index) {
-                            var key = modelKeys[index];
-                            return _.bind(function(callback) {
-                                var attrs = JSON.parse(modelJSON);
-                                loader[1](callback, attrs, key);
-                            }, this);
-                        }, this)), function(err, result) {
-                            callback();
-                        });
-                    }, this));
-                }, this));
-            }, this);
-        }, this)), function(err, results) {
+        function load (loader, done) {
+            var redisKey = loader[0];
+            var loadFunc = loader[1];
+            logger.info("loading " + redisKey)
+            async.waterfall([
+                // Get the key names of all the objects of this type in redis.
+                function (done) {
+                    that.redis.keys(redisKey, function(err, modelKeys) {
+                        if (err) {
+                            return done(err);
+                        }
+                        if (modelKeys.length == 0) {
+                            logger.warn("No redis data for " + redisKey);
+                            return done(null, null);
+                        }
+                        return done(null, modelKeys);
+                    });
+                },
+                // Grab all the JSON strings for those keys at once.
+                function (modelKeys, done) {
+                    if (!modelKeys) { return done(null, null); }
+                    that.redis.mget(modelKeys, function(err, modelsJSON) {
+                        if (err) { return done(err); }
+                        // Return a zipped array of both keys and modelsJSON.
+                        done(null, _.zip(modelKeys, modelsJSON));
+                    });
+                },
+                // Call loader callbacks for each JSON string.
+                function (keysAndAttrs, done) {
+                    if (!keysAndAttrs) { return done(); }
+                    async.map(keysAndAttrs, function(keyAndAttrs, cb) {
+                        var key = keyAndAttrs[0];
+                        var attrs = JSON.parse(keyAndAttrs[1]);
+                        // Intentionally using '!= null', which evaluates true
+                        // whether the arg is identical to `null` or identical
+                        // to `undefined`. Allow strings and 0's through.
+                        if (key != null && attrs != null) {
+                            loadFunc(cb, attrs, key);
+                        } else {
+                            cb();
+                        }
+                    }, done);
+                }
+            ], done);
+        };
+        async.mapSeries(loaders, load, function(err, results) {
             logger.info("Done loading models.");
             callback();
         });


### PR DESCRIPTION
Refactor the DB loading for two reasons:
1. The current loading depends on the order of reading keys from an
   object, which is problematic, as that ordering is undefined.  If
   `sessions` were loaded prior to `events` this would cause problems.  Use
   an array rather than object to store loaders.
2. Clarify the heavily nested loading function.  This new implementation
   is a bit more verbose, but I hope clearer:
   - use `async.waterfall` to control flow rather than nesting callbacks.
   - use `async.map` and `async.mapSeries` rather than nesting
     `async.parallel(_.map(...))`, etc.
   - use `that = this` as strategy for enclosing `this` rather than
     `_.bind`.  I'm a fan of `_.bind`, but when it gets 3 levels deep, it
     just gets hard to read.
