### PR TITLE
Avoid crash on redis error (issue #237)

### DIFF
--- a/lib/unhangout-db.js
+++ b/lib/unhangout-db.js
@@ -21,7 +21,7 @@ _.extend(UnhangoutDb.prototype, events.EventEmitter.prototype, {
 
         redis.auth(this.options.REDIS_PASSWORD);
         redis.on("end", function() { logger.error("redis end"); });
-        redis.on("error", function() { logger.error("redis error: " + err); });
+        redis.on("error", function(err) { logger.error("redis error: ", err); });
         redis.on("ready", function() { logger.info("redis ready"); });
         redis.once("ready", _.bind(function(err) {
             if (err) {


### PR DESCRIPTION
This doesn't address the "forever" crash (nor whatever caused redis to err in the first place), but it should fix the exception handling redis' error.
