### PR TITLE
Fix IE 10/11 failures in production

### DIFF
--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -36,7 +36,7 @@ $(document).ready(function() {
     // From here down, we're mostly concerned with managing networking and
     // communication.
     sock = new SockJS(document.location.protocol + "//" + document.location.hostname +
-            (document.location.port ? document.location.port + ":" : "") + "/sock");
+            (document.location.port ? ":" + document.location.port : "") + "/sock");
     // Register a bunch of listeners on the major events it will fire.
     sock.onopen = function() {
         // on connect, send the auth message.

--- a/public/js/facilitator.js
+++ b/public/js/facilitator.js
@@ -20,8 +20,8 @@ var FacilitatorView = Backbone.View.extend({
         this.session = options.session;
         this.event = options.event;
         this.sock = new SockJS(
-            document.location.protocol + "//" +
-            document.location.hostname + ":" + document.location.port + "/sock"
+            document.location.protocol + "//" + document.location.hostname +
+            (document.location.port ? ":" + document.location.port : "") + "/sock"
         );
         if (this.session.get("activities").length === 0) {
             this.session.set("activities", [{type: "about", autoHide: true}]);


### PR DESCRIPTION
IE 10 and 11 were failing on any deployment running on a standard port due to a bug in URL construction that interacted with IE's stricter URL parser.
