### PR TITLE
Synchronize event start/stop state on change

### DIFF
--- a/lib/server-models.js
+++ b/lib/server-models.js
@@ -177,12 +177,14 @@ exports.ServerEvent = client_models.Event.extend({
         var err = client_models.Event.prototype.start.call(this);
         if(err) return err;
         this.save();
+        this.trigger("broadcast", this, "event-update", this.toClientJSON());
     },
 
     stop: function() {
         var err = client_models.Event.prototype.stop.call(this);
         if(err) return err;
         this.save();
+        this.trigger("broadcast", this, "event-update", this.toClientJSON());
     },
 
     cleanDescription: function() {

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -395,6 +395,9 @@ $(document).ready(function() {
         // Make about pane hide itself.
         app.vent.trigger("about-nav", true);
     }
+    curEvent.on("change:start change:end", function() {
+        app.vent.trigger("about-nav", curEvent.isLive());
+    });
 
     // Handles clicks on the nav bar links.
     $("#about-nav").click(function(jqevt) {


### PR DESCRIPTION
Previously, starting or stopping the event was not auto-updating the
page without a refresh.  This commit fixes that.  Closes issue #313.
