### PR TITLE
allow custom CSS overrides via config options.

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -133,6 +133,11 @@ Create a file and copy the contents of conf.json.example file in it. Name this f
   - ``TESTING_SELENIUM_PATH``: The path to "selenium-server-standalone.jar",
     required to run tests with selenium.
 
+  - ``CUSTOM_CSS_FILES`` and ``CUSTOM_FACILITATOR_CSS_FILES``: An array of
+    paths to any custom CSS to include for both the main site and the
+    hangout facilitator gadget, respectively. Each path is injected into the
+    "href" attribute of a CSS declaration following the default declarations.
+
 E. Making changes to the codebase
 ---------------------------------
 

--- a/conf.json.example
+++ b/conf.json.example
@@ -35,5 +35,8 @@
     "TESTING_SELENIUM_PATH": "bin/selenium-server-standalone.jar",
     "TESTING_SELENIUM_VERBOSE": false,
     "TESTING_FIREFOX_BIN": null,
-    "MANDRILL_API_KEY": "...mandrill api key..."
+    "MANDRILL_API_KEY": "...mandrill api key...",
+
+    "CUSTOM_CSS_FILES": [],
+    "CUSTOM_FACILITATOR_CSS_FILES": []
 }

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -114,9 +114,11 @@ exports.UnhangoutServer.prototype = {
         // Much less repetitive to include these here, both for consistency
         // and because _header.ejs will only have access to these and
         // contexts passed in res.render().
+        this.app.locals.customCssFiles = [];
         if (!_.isEmpty(this.options.CUSTOM_CSS_FILES)) {
             this.app.locals.customCssFiles = this.options.CUSTOM_CSS_FILES;
         }
+        this.app.locals.customFacilitatorCssFiles = [];
         if (!_.isEmpty(this.options.CUSTOM_FACILITATOR_CSS_FILES)) {
             this.app.locals.customFacilitatorCssFiles = this.options.CUSTOM_FACILITATOR_CSS_FILES;
         }

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -111,6 +111,16 @@ exports.UnhangoutServer.prototype = {
             NODE_ENV: process.env.NODE_ENV
         }
 
+        // Much less repetitive to include these here, both for consistency
+        // and because _header.ejs will only have access to these and
+        // contexts passed in res.render().
+        if (!_.isEmpty(this.options.CUSTOM_CSS_FILES)) {
+            this.app.locals.customCssFiles = this.options.CUSTOM_CSS_FILES;
+        }
+        if (!_.isEmpty(this.options.CUSTOM_FACILITATOR_CSS_FILES)) {
+            this.app.locals.customFacilitatorCssFiles = this.options.CUSTOM_FACILITATOR_CSS_FILES;
+        }
+
         if(this.options.UNHANGOUT_USE_SSL) {
             try {
                 var privateKey = fs.readFileSync(this.options.UNHANGOUT_PRIVATE_KEY).toString();

--- a/views/_header.ejs
+++ b/views/_header.ejs
@@ -15,6 +15,11 @@
     <link href="/public/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.css" type="text/css" rel="stylesheet">
 
     <link href="/public/css/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
+    <% if (customCssFiles) { %>
+    <% customCssFiles.forEach(function(file) { %>
+        <link href="<%= file %>" media="screen, projection" rel="stylesheet" type="text/css">
+    <% }); %>
+    <% } %>
 
     <script type="text/javascript">
         /*

--- a/views/hangout-facilitator.ejs
+++ b/views/hangout-facilitator.ejs
@@ -1,5 +1,10 @@
 <% include _header.ejs %>
 <link rel='stylesheet' type='text/css' href='/public/css/facilitator.css' />
+<% if (customFacilitatorCssFiles) { %>
+<% customFacilitatorCssFiles.forEach(function(file) { %>
+    <link href="<%= file %>" media="screen, projection" rel="stylesheet" type="text/css">
+<% }); %>
+<% } %>
 
 <% if (!session) { %>
     <h2>Unhangout Facilitator</h2>


### PR DESCRIPTION
This patch allows custom installs to provide their own CSS overrides without editing the core CSS files directly.

This allows more control over site design while reducing the possibility of conflicts when merging upstream changes.

I considered auto-detecting specially named CSS files on server startup, and decided this method was both easier to implement and gave more control over deployment options.

Tested out the overrides for screen.css locally, and it's working beautifully.