### PR TITLE
add hotkey support for event admins.

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -2346,6 +2346,22 @@ user-admin-border-size = 2px
   }
 }
 
+/*-------------------------- HOTKEYS -----------------------*/
+
+
+.hotkey-help-item {
+  padding-left: 15px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.hotkey-key {
+  font-weight: bold;
+  margin-right: 5px;
+}
+
+.hotkey-description {
+}
 
 /*-------------------------- STATIC EVENT PAGE -----------------------*/
 

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -11,7 +11,8 @@ require([
     "jquery", "underscore", "backbone", "logger", "client-models",
     "event-views", "auth", "transport", 
     // plugins
-    "bootstrap", "backbone.marionette", "underscore-template-config"
+    "bootstrap", "backbone.marionette", "underscore-template-config",
+    "jquery.hotkeys"
 ], function($, _, Backbone, logging, models, eventViews, auth, transport) {
 
 var curEvent, messages;
@@ -156,6 +157,16 @@ $(document).ready(function() {
         this.dialogs.show(this.dialogView);
         this.top.show(this.aboutView);
 
+        $('#message-sessions-modal').on('shown.bs.modal', function (e) {
+            $('#session_message').focus();
+        });
+        $('#admin-hotkeys-help-modal').on('shown.bs.modal', function (e) {
+            $('#admin-hotkeys-help-modal .btn-default').focus();
+        });
+        $('#create-session-modal').on('shown.bs.modal', function (e) {
+            $('#session_name').focus();
+        });
+
         //On page reload show and hide topic list
         //according to the current mode
         if(!curEvent.get("adminProposedSessions")) {
@@ -176,6 +187,144 @@ $(document).ready(function() {
         // to do it.
         $(this.bar.el).hide();
 
+        this.initHotkeys = function() {
+            // These allow the hotkeys to work even when an input has the
+            // focus. Given the ctrl+shift prefix, this seems reasonable
+            // and safe, and avoids inconsistencies when using the hotkeys.
+            $.hotkeys.options.filterInputAcceptingElements = false;
+            $.hotkeys.options.filterContentEditable = false;
+            $.hotkeys.options.filterTextInputs = false;
+
+            var makeHotkey = function(key) {
+                var hotkey = 'ctrl+shift+' + key;
+                return hotkey;
+            }
+
+            // This allows use of the existing event handlers in
+            // adminButtonView.
+            // TODO: Abstract adminButtonViews functions more to separate the
+            // functionality we need here from the event callbacks.
+            var dummyEvent = {
+                preventDefault: function() {},
+            }
+
+            var hotkeysLog = function(event, funcName) {
+                logger.log(event.data.keys + ' hotkey pressed, calling: ' + funcName);
+            }
+
+            var help = function(data) {
+                hotkeysLog(data, 'help');
+                $('#admin-hotkeys-help-modal').modal('show');
+            }
+
+            var startStopEvent = function(data) {
+                if (curEvent.get('open')) {
+                    hotkeysLog(data, 'stopEvent');
+                    this.adminButtonView.stopEvent(dummyEvent);
+                }
+                else {
+                    hotkeysLog(data, 'startEvent');
+                    this.adminButtonView.startEvent(dummyEvent);
+                }
+            }
+
+            var editEvent = function(data) {
+                hotkeysLog(data, 'editEvent');
+                // jQuery's click() only deals with firing the click event, so
+                // use lower-level functionality.
+                // This approach allows the link itself to be configured to
+                // open in the same window or a new window.
+                document.getElementById("admin-page-for-event").click()
+            }
+
+            var createSession = function(data) {
+                hotkeysLog(data, 'createSession');
+                $('#create-session-modal').modal('show');
+            }
+
+            var openSessions = function(data) {
+                hotkeysLog(data, 'openSessions');
+                this.adminButtonView.openSessions(dummyEvent);
+            }
+
+            var closeSessions = function(data) {
+                hotkeysLog(data, 'closeSessions');
+                this.adminButtonView.closeSessions(dummyEvent);
+            }
+
+            var messageSessions = function(data) {
+                hotkeysLog(data, 'messageSessions');
+                this.adminButtonView.messageSessions(dummyEvent);
+            }
+
+            var enableDisableParticipantProposedMode = function(data) {
+                if (curEvent.get('adminProposedSessions')) {
+                    hotkeysLog(data, 'enableParticipantProposedMode');
+                    this.adminButtonView.enableParticipantProposedMode(dummyEvent);
+                }
+                else {
+                    hotkeysLog(data, 'disableParticipantProposedMode');
+                    this.adminButtonView.disableParticipantProposedMode(dummyEvent);
+                }
+            }
+
+            var focusChatMessage = function(data) {
+                hotkeysLog(data, 'focusChatMessage');
+                $("#chat-input").focus();
+            }
+
+            var highlightChatMessage = function(data) {
+                hotkeysLog(data, 'highlightChatMessage');
+                $("[name='chat-as-admin']").click();
+            }
+
+            var editWhiteboard = function(data) {
+                hotkeysLog(data, 'editWhiteboard');
+                $("#whiteboard-buttons .edit-whiteboard").click();
+            }
+
+            var bindings = {
+                '/': help,
+                s: startStopEvent,
+                e: editEvent,
+                c: createSession,
+                o: openSessions,
+                w: closeSessions,
+                m: messageSessions,
+                p: enableDisableParticipantProposedMode,
+                a: focusChatMessage,
+                h: highlightChatMessage,
+                b: editWhiteboard,
+            }
+
+            var boundFunctions = {};
+
+            var bindingsCallback = function(func, key) {
+                var boundFunc = _.bind(func, this);
+                boundFunctions[key] = boundFunc;
+            }
+            _.each(bindings, _.bind(bindingsCallback, this));
+
+            var activate = function(el) {
+                var callback = function(func, key) {
+                    el.bind('keydown', makeHotkey(key), func);
+                }
+                _.each(boundFunctions, callback);
+            }
+
+            var deactivate = function(el) {
+                var callback = function(func, key) {
+                    el.unbind('keydown', func);
+                }
+                _.each(boundFunctions, callback);
+            }
+
+            return {
+              activate: activate,
+              deactivate: deactivate,
+            }
+        }
+
         // obviously this is not secure, but any admin requests are re-authenticated on
         // the server. Showing the admin UI is harmless if a non-admin messes with it.
         if(IS_ADMIN) {
@@ -184,6 +333,8 @@ $(document).ready(function() {
             });
 
             this.admin.show(this.adminButtonView);
+            this.hotkeys = this.initHotkeys();
+            this.hotkeys.activate($(document));
         }
 
         var maybeMute = function() {

--- a/public/js/requirejs-config.json
+++ b/public/js/requirejs-config.json
@@ -6,6 +6,7 @@
     "optimize": "uglify2",
     "paths": {
         "jquery": "../vendor/jquery-2.0.0",
+        "jquery.hotkeys": "../vendor/jquery.hotkeys",
         "jquery.validate": "../vendor/jquery.validate.min",
         "jquery.autosize": "../vendor/jquery.autosize.min",
         "jquery-ui": "../vendor/jquery-ui-1.10.3.custom.min",
@@ -23,6 +24,7 @@
     "shim": {
         "jquery": { "exports": "jQuery" },
         "jquery-ui": { "deps": ["jquery"], "exports": "jQuery.fn.ui" },
+        "jquery.hotkeys": { "deps": ["jquery"] },
         "jquery.validate": { "deps": ["jquery"], "exports": "jQuery.fn.validate" },
         "jquery.autosize": { "deps": ["jquery"], "exports": "jQuery.fn.autosize" },
         "underscore": { "exports": "_" },

--- a/public/vendor/jquery.hotkeys.js
+++ b/public/vendor/jquery.hotkeys.js
@@ -1,0 +1,204 @@
+/*jslint browser: true*/
+/*jslint jquery: true*/
+
+/*
+ * jQuery Hotkeys Plugin
+ * Copyright 2010, John Resig
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Based upon the plugin by Tzury Bar Yochay:
+ * https://github.com/tzuryby/jquery.hotkeys
+ *
+ * Original idea by:
+ * Binny V A, http://www.openjs.com/scripts/events/keyboard_shortcuts/
+ */
+
+/*
+ * One small change is: now keys are passed by object { keys: '...' }
+ * Might be useful, when you want to pass some other data to your handler
+ */
+
+(function(jQuery) {
+
+  jQuery.hotkeys = {
+    version: "0.8",
+
+    specialKeys: {
+      8: "backspace",
+      9: "tab",
+      10: "return",
+      13: "return",
+      16: "shift",
+      17: "ctrl",
+      18: "alt",
+      19: "pause",
+      20: "capslock",
+      27: "esc",
+      32: "space",
+      33: "pageup",
+      34: "pagedown",
+      35: "end",
+      36: "home",
+      37: "left",
+      38: "up",
+      39: "right",
+      40: "down",
+      45: "insert",
+      46: "del",
+      59: ";",
+      61: "=",
+      96: "0",
+      97: "1",
+      98: "2",
+      99: "3",
+      100: "4",
+      101: "5",
+      102: "6",
+      103: "7",
+      104: "8",
+      105: "9",
+      106: "*",
+      107: "+",
+      109: "-",
+      110: ".",
+      111: "/",
+      112: "f1",
+      113: "f2",
+      114: "f3",
+      115: "f4",
+      116: "f5",
+      117: "f6",
+      118: "f7",
+      119: "f8",
+      120: "f9",
+      121: "f10",
+      122: "f11",
+      123: "f12",
+      144: "numlock",
+      145: "scroll",
+      173: "-",
+      186: ";",
+      187: "=",
+      188: ",",
+      189: "-",
+      190: ".",
+      191: "/",
+      192: "`",
+      219: "[",
+      220: "\\",
+      221: "]",
+      222: "'"
+    },
+
+    shiftNums: {
+      "`": "~",
+      "1": "!",
+      "2": "@",
+      "3": "#",
+      "4": "$",
+      "5": "%",
+      "6": "^",
+      "7": "&",
+      "8": "*",
+      "9": "(",
+      "0": ")",
+      "-": "_",
+      "=": "+",
+      ";": ": ",
+      "'": "\"",
+      ",": "<",
+      ".": ">",
+      "/": "?",
+      "\\": "|"
+    },
+
+    // excludes: button, checkbox, file, hidden, image, password, radio, reset, search, submit, url
+    textAcceptingInputTypes: [
+      "text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime",
+      "datetime-local", "search", "color", "tel"],
+
+    // default input types not to bind to unless bound directly
+    textInputTypes: /textarea|input|select/i,
+
+    options: {
+      filterInputAcceptingElements: true,
+      filterTextInputs: true,
+      filterContentEditable: true
+    }
+  };
+
+  function keyHandler(handleObj) {
+    if (typeof handleObj.data === "string") {
+      handleObj.data = {
+        keys: handleObj.data
+      };
+    }
+
+    // Only care when a possible input has been specified
+    if (!handleObj.data || !handleObj.data.keys || typeof handleObj.data.keys !== "string") {
+      return;
+    }
+
+    var origHandler = handleObj.handler,
+      keys = handleObj.data.keys.toLowerCase().split(" ");
+
+    handleObj.handler = function(event) {
+      //      Don't fire in text-accepting inputs that we didn't directly bind to
+      if (this !== event.target &&
+        (jQuery.hotkeys.options.filterInputAcceptingElements &&
+          jQuery.hotkeys.textInputTypes.test(event.target.nodeName) ||
+          (jQuery.hotkeys.options.filterContentEditable && jQuery(event.target).attr('contenteditable')) ||
+          (jQuery.hotkeys.options.filterTextInputs &&
+            jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
+        return;
+      }
+
+      var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[event.which],
+        character = String.fromCharCode(event.which).toLowerCase(),
+        modif = "",
+        possible = {};
+
+      jQuery.each(["alt", "ctrl", "shift"], function(index, specialKey) {
+
+        if (event[specialKey + 'Key'] && special !== specialKey) {
+          modif += specialKey + '+';
+        }
+      });
+
+      // metaKey is triggered off ctrlKey erronously
+      if (event.metaKey && !event.ctrlKey && special !== "meta") {
+        modif += "meta+";
+      }
+
+      if (event.metaKey && special !== "meta" && modif.indexOf("alt+ctrl+shift+") > -1) {
+        modif = modif.replace("alt+ctrl+shift+", "hyper+");
+      }
+
+      if (special) {
+        possible[modif + special] = true;
+      }
+      else {
+        possible[modif + character] = true;
+        possible[modif + jQuery.hotkeys.shiftNums[character]] = true;
+
+        // "$" can be triggered as "Shift+4" or "Shift+$" or just "$"
+        if (modif === "shift+") {
+          possible[jQuery.hotkeys.shiftNums[character]] = true;
+        }
+      }
+
+      for (var i = 0, l = keys.length; i < l; i++) {
+        if (possible[keys[i]]) {
+          return origHandler.apply(this, arguments);
+        }
+      }
+    };
+  }
+
+  jQuery.each(["keydown", "keyup", "keypress"], function() {
+    jQuery.event.special[this] = {
+      add: keyHandler
+    };
+  });
+
+})(jQuery || this.jQuery || window.jQuery);

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -830,6 +830,66 @@
         </div>
     </div>
 
+    <!-- Admin hotkeys help dialog -->
+    <div id="admin-hotkeys-help-modal" class="modal fade" role="dialog" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Hotkeys help</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+?:</span>
+                        <span class="hotkey-description">This help menu</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+S:</span>
+                        <span class="hotkey-description">Start/Stop event</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+E:</span>
+                        <span class="hotkey-description">Edit event</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+C:</span>
+                        <span class="hotkey-description">Create session</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+O:</span>
+                        <span class="hotkey-description">Open sessions</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+W:</span>
+                        <span class="hotkey-description">Close sessions</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+M:</span>
+                        <span class="hotkey-description">Send message to sessions</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+P:</span>
+                        <span class="hotkey-description">Toggle participant proposed sessions</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+A:</span>
+                        <span class="hotkey-description">Cursor to chat message box</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+H:</span>
+                        <span class="hotkey-description">Highlight/unhighlight chat message</span>
+                    </div>
+                    <div class="hotkey-help-item">
+                        <span class="hotkey-key">CTRL+SHIFT+B:</span>
+                        <span class="hotkey-description">Edit whiteboard</span>
+                    </div>
+                </div>
+                <div class='modal-footer'>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="modal hide fade started-modal">
         <div class="modal-header"><h3></h3></div>
         <div class="modal-body">


### PR DESCRIPTION
this adds keyboard shortcuts (hotkeys) for most or all major actions that an event admin needs to take. combined with the auto-focusing on a few dialogs, a drastic increase in efficiency is achieved in administering events.

the one thing i thought about doing differently was auto-generating the help dialog based on the javascript key mappings (to reduce duplication), and decided the static help dialog is good enough for now.

hitting CRTL+SHIFT+? brings up the help dialog which has all the other hotkey combinations listed. CTRL+SHIFT is a bit bulky for the meta key prefix, but i also wanted the key combinations to be fairly conservative in terms of colliding with other keyboard shortcuts. and have the meta key prefix be consistent among the hotkeys.