### PR TITLE
add UNHANGOUT_HANGOUT_URLS_WARNING config option, make warning dialog work

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -140,6 +140,11 @@ Create a file and copy the contents of conf.json.example file in it. Name this f
     writeable by the user running the Node process. Relative paths will be
     appended to the application root. Default is ``logs``.
 
+  - ``UNHANGOUT_HANGOUT_URLS_WARNING``: Throw a warning dialog on event pages
+    when the number of farmed Hangout URLs available (as detailed in
+    [DEVELOPMENT.md](DEVELOPMENT.md), Hangout Creation section) falls below
+    this number. Default is 10, set to 0 to disable the warning.
+
   - ``TESTING_SELENIUM_PATH``: The path to "selenium-server-standalone.jar",
     required to run tests with selenium.
 

--- a/conf.json.example
+++ b/conf.json.example
@@ -32,6 +32,7 @@
 
     "EMAIL_LOG_RECIPIENTS": ["sysadmin1@example.com"],
     "UNHANGOUT_LOG_DIR": "logs",
+    "UNHANGOUT_HANGOUT_URLS_WARNING": 10,
     "TESTING_SELENIUM_PATH": "bin/selenium-server-standalone.jar",
     "TESTING_SELENIUM_VERBOSE": false,
     "TESTING_FIREFOX_BIN": null,

--- a/lib/options.js
+++ b/lib/options.js
@@ -14,6 +14,7 @@ var options = _.extend({
     UNHANGOUT_SESSION_SECRET: "fake secret",
     UNHANGOUT_SERVER_EMAIL_ADDRESS: "node@localhost",
     UNHANGOUT_LOG_DIR: "logs",
+    UNHANGOUT_HANGOUT_URLS_WARNING: 10,
     EVENT_EDIT_NOTIFICATION_DELAY: 60000 * 5,
     // Permit more lag in non-production environments. Testing in particular
     // maxes out the server to maximize execution speed.

--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -67,7 +67,13 @@ module.exports = {
             if (!event) {
                 return res.send(404, "404 Not Found");
             }
-            context = {user: req.user, event: event, title: event.get("title")};
+            context = {
+                user: req.user,
+                event: event,
+                title: event.get("title"),
+                numHangoutUrlsAvailable: farming.getNumHangoutsAvailable(),
+                numHangoutUrlsWarning: options.UNHANGOUT_HANGOUT_URLS_WARNING,
+            };
 
             var template;
             var isOverflowed = event.get("connectedUsers").length >= event.get("overflowUserCap");

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -179,6 +179,9 @@ $(document).ready(function() {
         // obviously this is not secure, but any admin requests are re-authenticated on
         // the server. Showing the admin UI is harmless if a non-admin messes with it.
         if(IS_ADMIN) {
+            if (NUM_HANGOUT_URLS_WARNING > 0 && NUM_HANGOUT_URLS_AVAILABLE < NUM_HANGOUT_URLS_WARNING) {
+                $("#no-urls-warning").modal('show');
+            }
             this.adminButtonView = new eventViews.AdminButtonView({
                 event: curEvent, transport: trans
             });

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -6,6 +6,8 @@
     var IS_ADMIN = <%= event && user.isAdminOf(event) %>;
     var IS_SUPERUSER = <%= event && user.isSuperuser() %>;
     var USER = <%- JSON.stringify(user) %>;
+    var NUM_HANGOUT_URLS_AVAILABLE = <%= numHangoutUrlsAvailable %>;
+    var NUM_HANGOUT_URLS_WARNING = <%= numHangoutUrlsWarning %>;
 
     <% if(!_.isUndefined(event)) { %>
         var EVENT_ATTRS = <%- JSON.stringify(event.toClientJSON()) %>;
@@ -1102,17 +1104,20 @@
         </div>
     </div>
 
-    <div id="no-urls-warning" class="modal hide fade">
-        <div class="modal-header"><h3>NO HANGOUT URLS AVAILABLE</h3></div>
-        <div class="modal-body">
-            <p>There are currently no hangout urls available on the server. Sessions started when there are no urls available will fall back to the callback method of hangout starting, which requires the first person to join a session to create the hangout. This is not desireable; we strongly recommend you farm some hangout urls by clicking "farm" below. For this process to work, your google acount must have "create video calls for events" set in your google calendar account settings.
-        </div>
-        <div class="modal-footer">
-            <a class="btn btn-success" id="farm-urls" href="/hangout-farming" target="_blank">Farm</a>
-            <a href="#" class="btn btn-primary" id="dismiss-farming-warning" data-dismiss='modal'>Dismiss</a>
+    <div class="modal fade" id="no-urls-warning" role="dialog" aria-hidden="true">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>NO HANGOUT URLS AVAILABLE</h3>
+            </div>
+            <div class="modal-body alert alert-danger">
+                    <p>There are currently <strong><%= numHangoutUrlsAvailable %></strong> Hangout urls available on the server. Sessions started when there are no urls available will fall back to the callback method of hangout starting, which requires the first person to join a session to create the hangout. This is not desireable; we strongly recommend you farm some hangout urls by clicking "farm" below. For this process to work, your google acount must have "create video calls for events" set in your google calendar account settings.
+            </div>
+            <div class="modal-footer">
+                <a class="btn btn-success" id="farm-urls" href="/hangout-farming" target="_blank">Farm</a>
+                <a href="#" class="btn btn-default" id="dismiss-farming-warning" data-dismiss='modal'>Dismiss</a>
+            </div>
         </div>
     </div>
-
     
 </script>
 


### PR DESCRIPTION
i noticed there was an unused warning dialog in event.ejs for a low number of farmed hangout URLs.

having this warning when the number of farmed hangouts drops below a specified number is a handy feature for our site, so i went ahead and got it working.

i figured that some installs might not want it at all, and some might want the warning thrown at differing numbers of available farmed hangouts, and the UNHANGOUT_HANGOUT_URLS_WARNING config option provides for those use cases.