### PR TITLE
extend UserList model for client, use on admin/users for basic sorting

### DIFF
--- a/public/js/admin-users.js
+++ b/public/js/admin-users.js
@@ -6,7 +6,7 @@ require([
 
 $(document).ready(function() {
 
-var users = new models.UserList(USER_DATA);
+var users = new models.ClientUserList(USER_DATA);
 var events = new models.EventList(EVENT_DATA);
 
 var UserRowView = Backbone.Marionette.ItemView.extend({
@@ -159,7 +159,7 @@ var UserTableView = Backbone.Marionette.CompositeView.extend({
         // Clone users so we can manipulate it later.
         this.limit = 20;
         this.filter = {};
-        this.collection = new models.UserList();
+        this.collection = new models.ClientUserList();
         this.applyFilters();
     },
     serializeData: function() {

--- a/public/js/client-models.js
+++ b/public/js/client-models.js
@@ -26,6 +26,20 @@ models.ClientEvent = models.Event.extend({
     },
 });
 
+models.ClientUserList = models.UserList.extend({
+
+    initialize: function(options) {
+        models.UserList.prototype.initialize.call(this, options);
+    },
+
+    comparator: function(a, b) {
+        // Sort by displayName.
+        var a_name = a.get('displayName');
+        var b_name = b.get('displayName');
+        return a_name > b_name ? 1 : a_name < b_name ? -1 : 0;
+    }
+});
+
 return models;
 
 });


### PR DESCRIPTION
This rolls a ClientUserList model, extending the base UserList model,
and uses it to order the users on the admin page. This probably needs
further treatment, possibly into full table sorting code, but it's
certainly an improvement to at least have a basic alphabetical sorting
on the admin page.