### PR TITLE
move server user model defaults to base user defaults.

### DIFF
--- a/lib/server-models.js
+++ b/lib/server-models.js
@@ -33,12 +33,6 @@ exports.ServerUser = client_models.User.extend({
     urlRoot: "user",
     adminCache: {},
 
-    defaults: {
-        picture: "",
-        createdViaHangout: false // this field is set in situations where the user doesn't actually log in with us, but
-                                 // instead shows up in a participants message from an instrumented hangout.
-    },
-
     getSockKey: function() {
         if(_.isUndefined(this.get("sock-key"))) {
             this.set("sock-key", exports.generateSockKey(this.id));

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -431,8 +431,11 @@ models.User = Backbone.Model.extend({
             displayName: "[unknown]",
             link: null,
             emails: [],
-            preferredContact: null,
-            networkList: {}
+            preferredContact: {},
+            networkList: {},
+            picture: "",
+            createdViaHangout: false // this field is set in situations where the user doesn't actually log in with us, but
+                                 // instead shows up in a participants message from an instrumented hangout.
         };
     },
 


### PR DESCRIPTION
When extending a Backbone model, the base class defaults are completely overridden if they are declared in the new class. The ServerUser model suffers from this problem when it extends the base User class.

This patch simply moves those declared defaults to the base User class, as I figured that was the simplest and cleanest approach. 

Another workable approach is outlined here: http://jsfiddle.net/mattfreer/xLK5D/ -- if you'd rather me take that approach I can easily do that instead.