### PR TITLE
add event status indicator to event nav bar.

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -546,6 +546,23 @@ hr.noshade {
   }
 }
 
+#admin-button {
+  .status {
+    display: none;
+    float: left;
+    margin-top: 7px;
+    border-radius: 50%;
+    width: 8px;
+    height: 8px;
+  }
+  .status.open {
+    background: #5CB85C;
+  }
+  .status.closed {
+    background: #D9524F;
+  }
+}
+
 .event-page-container {
   margin-top: 0px;
   height: 100%;

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -182,7 +182,6 @@ $(document).ready(function() {
             this.adminButtonView = new eventViews.AdminButtonView({
                 event: curEvent, transport: trans
             });
-            this.adminButtonView.setEventStatusIndicator();
 
             this.admin.show(this.adminButtonView);
         }

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -182,6 +182,7 @@ $(document).ready(function() {
             this.adminButtonView = new eventViews.AdminButtonView({
                 event: curEvent, transport: trans
             });
+            this.adminButtonView.setEventStatusIndicator();
 
             this.admin.show(this.adminButtonView);
         }
@@ -226,8 +227,6 @@ $(document).ready(function() {
         $("#twitter_handle").val(USER.preferredContact.twitterHandle);
         $("#linkedin_url").val(USER.preferredContact.linkedinURL);
         $("#noShareChkBox").prop("checked", USER.preferredContact.noShare);
-
-        this.adminButtonView.setEventStatusIndicator();
 
     }, app);
 

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -227,6 +227,8 @@ $(document).ready(function() {
         $("#linkedin_url").val(USER.preferredContact.linkedinURL);
         $("#noShareChkBox").prop("checked", USER.preferredContact.noShare);
 
+        this.adminButtonView.setEventStatusIndicator();
+
     }, app);
 
     app.vent.on("about-nav", _.bind(function(hide) {

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -929,10 +929,15 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
     },
 
     _startStopEvent: function(action) { 
+        var self = this;
         $.ajax({
             type: 'POST',
             url: "/admin/event/" + this.options.event.id + "/" + action
-        }).fail(function(err) {
+        })
+        .done(function(data) {
+          self.setEventStatusIndicator();
+        })
+        .fail(function(err) {
             logger.error(err);
             alert("Server error!");
         });
@@ -958,6 +963,20 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
     messageSessions: function(jqevt) {
         jqevt.preventDefault();
         $("#message-sessions-modal").modal('show');
+    },
+
+    setEventStatusIndicator: function(jqevt) {
+      var open = this.options.event.get('open');
+      var statusIndicator = $('#admin-button .status');
+      if (open) {
+        statusIndicator.addClass('open');
+        statusIndicator.removeClass('closed');
+      }
+      else {
+        statusIndicator.addClass('closed');
+        statusIndicator.removeClass('open');
+      }
+      statusIndicator.show();
     },
 
     serializeData: function() {

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -967,7 +967,7 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
 
     setEventStatusIndicator: function(jqevt) {
       var open = this.options.event.get('open');
-      var statusIndicator = $('#admin-button .status');
+      var statusIndicator = this.$el.find('.status');
       if (open) {
         statusIndicator.addClass('open');
         statusIndicator.removeClass('closed');
@@ -977,6 +977,10 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
         statusIndicator.removeClass('open');
       }
       statusIndicator.show();
+    },
+
+    onRender: function() {
+      this.setEventStatusIndicator();
     },
 
     serializeData: function() {

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -571,6 +571,7 @@
 </script>
 
 <script type="text/template" id="admin-button-template">
+    <span class="status"></span>
     <div class="dropdown">
         <a class="dropdown-toggle admin-button" data-toggle="dropdown"
            id='event-settings-label'> 


### PR DESCRIPTION
we've found it inconvenient to click the event admin button to see the current status of the event. sure, you can also tell by the fact that the chat input box is disabled, but this is an indirect indication, and we want it to be easier for our event admins.

this adds a small status indicator circle to the left of the event admin drop down, which clearly shows the event's open or closed status, using the same colors as the 'OPEN' and 'CLOSED' words have inside the admin dropdown.

my CSS foo is weak -- i'm guessing there might be a more elegant way to position the circle, and what i have works. :)