### PR TITLE
use uuid instead of crypto for session-key generation.

### DIFF
--- a/lib/server-models.js
+++ b/lib/server-models.js
@@ -5,7 +5,8 @@ var client_models = require('../public/js/models.js'),
     crypto = require('crypto'),
     conf = require("./options"),
     utils = require("./utils"),
-    deepCopy = require("deep-copy");
+    deepCopy = require("deep-copy"),
+    uuid = require('node-uuid');
 
 // This file contains extensions to the core models defined in
 // public/js/models.js.
@@ -475,10 +476,8 @@ exports.ServerSession = client_models.Session.extend({
         // make sure not to overwrite the built-in session-key
         // if we've loaded one through the db.
         if(_.isNull(this.get("session-key"))) {
-            var shasum = crypto.createHash('sha256');
-            shasum.update(this.get("id") + "");
-            shasum.update(new Date().getTime() + "");
-            this.set("session-key", shasum.digest('hex'));
+            var sessionKey = uuid.v4();
+            this.set("session-key", sessionKey);
         }
     },
     // Add a user to the list of `joiningParticipants` -- people who we're


### PR DESCRIPTION
This fixes a race condition when sessions are created at the same time.
Since the session has not been saved yet, it has no id, thus sessions
created at the exact same time have the exact same session-key. Using
the existing node-uuid module is a clean, simple solution.