### PR TITLE
Remove unneeded sessions collection.remove after session.destroy.

### DIFF
--- a/lib/unhangout-sockets.js
+++ b/lib/unhangout-sockets.js
@@ -305,7 +305,6 @@ _.extend(UnhangoutSocketManager.prototype, events.EventEmitter.prototype, {
                         session.get("proposedBy").id === socket.user.id)) {
 
                         session.destroy();
-                        event.get("sessions").remove(session);
                         mgr.writeAck(socket, "delete-session");
                         event.logAnalytics({action: "delete-session", user: socket.user, session: args.id});
                         return;


### PR DESCRIPTION
I tested this, and as far as I can tell, there's no need to remove a destroyed session
from its events 'sessions' collection -- this is handled automatically by backbone,
and is reflected across connected users. I also suspect this may contribute to a weird
intermittent bug I've seen where users joining a new session are erroneously
connected to a deleted session they had previously joined.