### PR TITLE
fix broken selenium farming script.

### DIFF
--- a/bin/selenium-farmer.js
+++ b/bin/selenium-farmer.js
@@ -19,7 +19,9 @@
 */
 
 var common = require("../test/common.js"),
-    farmConf = require("../farmingConf.json");
+    farmConf = require("../farmingConf.json"),
+    logger = require("../lib/logging").getLogger(),
+    util = require("util");
 
 function run(callback) {
     common.getSeleniumBrowser(function(browser) {
@@ -27,6 +29,7 @@ function run(callback) {
         browser.get(farmConf.serverUrl);
         browser.byLinkText("Login").click();
         browser.byCss("#Email").sendKeys(farmConf.email);
+        browser.byCss("#next").click();
         browser.byCss("#Passwd").sendKeys(farmConf.password);
         browser.byCss("#signIn").click();
         browser.getCurrentUrl().then(function(url) {
@@ -60,6 +63,7 @@ function run(callback) {
             var count = parseInt(match[1]);
             for (var i = count; i < farmConf.count; i++) {
                 browser.byLinkText("CLICK ME").click();
+                logger.debug(util.format("Farmed %s of %s", i + 1, farmConf.count));
                 browser.waitTime(5000);
             };
             browser.then(function() {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "libxmljs": "git://github.com/gwicke/libxmljs.git#7e1ceaf",
     "mailparser": "~0",
     "mocha": "1.18.2",
-    "selenium-webdriver": "2.44.0",
+    "selenium-webdriver": "2.46.1",
     "should": "3.2.0-beta1",
     "simplesmtp": "~0",
     "sinon": "1.10.3",


### PR DESCRIPTION
This fix addresses two issues that disabled the selenium farming script:
 1) An older version of the selenium-webdriver package was resulting in
    server start errors. Upgrading the package fixed the issue.
 2) Google changed its login workflow to require an extra click between
    entering a username and a password.
I also added some light output to the script, so users and/or cron script
output can have some idea of what's going on.