### PR TITLE
make current events calendar more accessible and flexible.

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -2055,6 +2055,10 @@ user-admin-border-size = 2px
     margin-bottom: 20px;
   }
 
+  .manage-calendar {
+    float:right;
+  }
+
   .upcomingEventsTitle{
     margin-top: 40px;
   }

--- a/public/js/events-spreadsheet.js
+++ b/public/js/events-spreadsheet.js
@@ -15,7 +15,13 @@ define(["jquery", "underscore", "moment", "underscore-template-config"], functio
       cell = data.feed.entry[i];
       col = cell.title.$t.substring(0, 1);
       if (col === 'A') {
-        entry = {};
+        entry = {
+          title: "[No title]",
+          description: null,
+          image: null,
+          date: null,
+          link: null
+        };
         rows.push(entry);
       }
       entry[mapping[col]] = cell.content.$t;

--- a/views/events.ejs
+++ b/views/events.ejs
@@ -2,6 +2,13 @@
 <% include _navbar.ejs %>
 
 <div class="container event-container" id='events-list' data-spreadsheet-key="<%= spreadsheetKey %>">
+
+      <% if (user && (user.isSuperuser() || user.isAdminOfSomeEvent())) { %>
+          <p>
+              <a href="https://docs.google.com/spreadsheets/d/<%= spreadsheetKey %>" target="_blank" class="manage-calendar">Manage calendar</a>
+          </p>
+      <% } %>
+
       <h3 class="upcomingEventsTitle">Upcoming Events</h3> 
       <div class="row" id="upcomingEvents"></div> 
  
@@ -13,11 +20,26 @@
 <script type='text/template' id='event-listing'>
     <div class='event-box col-lg-3 col-md-4 col-sm-6'>
       <div class='container event-box-content'>
-        <a href='{{= link }}'>
-            <img class='img-responsive event-image' src='{{= image }}'/>
-        </a>
-        <h4><a href='{{= link }}'>{{= title }}</a></h4>
-        <p class='date'>{{= date.format("MMM D, YYYY, h:mm a [GMT]Z")}}</p>
+        {{ if (image) { }}
+            {{ if (link) { }}
+                <a href='{{= link }}'>
+                    <img class='img-responsive event-image' src='{{= image }}'/>
+                </a>
+            {{ } else { }}
+                <img class='img-responsive event-image' src='{{= image }}'/>
+            {{ } }}
+        {{ } }}
+        {{ if (link) { }}
+            <h4><a href='{{= link }}'>{{= title }}</a></h4>
+        {{ } else { }}
+            <h4>{{= title }}</h4>
+        {{ } }}
+        {{ if (date) { }}
+            <p class='date'>{{= date.format("MMM D, YYYY, h:mm a [GMT]Z")}}</p>
+        {{ } }}
+        {{ if (description) { }}
+            <p class='description'>{{= description }}</p>
+        {{ } }}
     </div>
     </div>
 </script>


### PR DESCRIPTION
Although it's likely that the old system for the events calendar is
going away, it's still active. This fix accomplishes two things:

 1) Adds a 'Manage calendar' link to the events page, displayed for
    anyone who is an event admin.
 2) Makes the system more flexible with what data you give it. This
    is nice in the case where you don't have an event link yet, or
    don't want and image or description for the event -- the
    calendar won't puke now if you leave these out.