### PR TITLE
add destination handling for event admin page.

### DIFF
--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -483,7 +483,8 @@ module.exports = {
             res.render(templateName, {
                 user: req.user,
                 events: allowedEvents,
-                permalinkSessions: permalinkSessions
+                permalinkSessions: permalinkSessions,
+                destination: req.url,
             });
         }
 
@@ -765,7 +766,8 @@ module.exports = {
             res.render('admin-event.ejs', {
                 user: req.user,
                 event: event,
-                errors: {}
+                errors: {},
+                destination: req.query.destination || ""
             })
         });
 
@@ -795,7 +797,12 @@ module.exports = {
                 event.save();
                 event.trigger("broadcast", event, "event-update", event.toClientJSON());
             }
-            res.redirect(event.getEventUrl());
+            if (req.query.destination) {
+              res.redirect(req.query.destination);
+            }
+            else {
+              res.redirect(event.getEventUrl());
+            }
         });
 
         //

--- a/views/admin-event.ejs
+++ b/views/admin-event.ejs
@@ -12,7 +12,7 @@
     <br/>
 
         <form class="form-horizontal"
-              action="/admin/event/<%= event.id || "new" %>"
+              action="/admin/event/<%= event.id && event.id + "?destination=" + encodeURIComponent(destination) || "new" %>"
               method="post" encoding="application/x-www-form-urlencoded">
 
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -36,7 +36,7 @@
                                     data-event='<%= event.id %>'>start</button>
                         </form>
                     <% } %>
-                    <a href="/admin/event/<%=event.id%>" class="btn btn-small">
+                    <a href="/admin/event/<%=event.id + '?destination=' + encodeURIComponent(destination)%>" class="btn btn-small">
                         <i class='icon-pencil' title='Edit'></i> edit
                     </a>
                     <span class='small-green'><%= baseUrl + event.getEventUrl() %></span>


### PR DESCRIPTION
This allows a destination= param to be passed to the event admin
page, which will direct the user back to the original page after
event save. Implemented for the admin page. I'm not sure this is
the cleanest implementation, so please feel free to offer improvements,
threw it together quickly for my own site needs.