### PR TITLE
fix permission change triggering.

### DIFF
--- a/public/js/models.js
+++ b/public/js/models.js
@@ -490,12 +490,10 @@ models.User = Backbone.Model.extend({
     },
 
     setPerm: function(perm, val, options) {
-        if (!this.get("perms")) {
-            this.set("perms", {}, {silent: true});
-        }
-        this.get("perms")[perm] = val;
-        if (!(options && options.silent)) {
-            this.trigger("change:perms");
+        var perms = _.clone(this.get("perms") || {});
+        if (perms[perm] !== val) {
+            perms[perm] = val;
+            this.set("perms", perms, {silent: options && options.silent});
         }
     },
 


### PR DESCRIPTION
The initial implementation of triggering for permissions was not
robust enough for practical usage. This re-implements the funcitonality
using a more traditional backbone approach.