### PR TITLE
fix erroneous check for model name in set operation.

### DIFF
--- a/public/js/transport.js
+++ b/public/js/transport.js
@@ -206,7 +206,7 @@ _.extend(Transport.prototype, Backbone.Events, {
         // Execute operations on the model.
         switch (args.op) {
             case "set":
-                if (name === null) {
+                if (_.isEmpty(name)) {
                     model.set(value);
                 } else {
                     model.set(name, value);
@@ -214,7 +214,7 @@ _.extend(Transport.prototype, Backbone.Events, {
                 break;
 
             case "unset":
-                if (name !== null) {
+                if (!_.isEmpty(name)) {
                     model.unset(name);
                 } else {
                     return logger.error("Cannot unset a null name");


### PR DESCRIPTION
MDN insists that the return value of pop() when no array element is present is
undefined. W3Schools doesn't specify the value in this case. It seems best to
code defensively for this check and use underscore's isEmpty method.