### PR TITLE
default sorting for users by display name.

### DIFF
--- a/public/js/models.js
+++ b/public/js/models.js
@@ -551,6 +551,12 @@ models.UserList = Backbone.Collection.extend({
         return this.find(function(u) {
             return _.contains(_.pluck(u.get("emails"), "value"), email);
         });
+    },
+    comparator: function(a, b) {
+        // Default sorting by displayName.
+        var a_name = a.get('displayName');
+        var b_name = b.get('displayName');
+        return a_name > b_name ? 1 : a_name < b_name ? -1 : 0;
     }
 });
 

--- a/test/test.admin-users.selenium.js
+++ b/test/test.admin-users.selenium.js
@@ -89,7 +89,7 @@ describe("ADMIN USERS SELENIUM", function() {
         var event = common.server.db.events.findWhere({shortName: "writers-at-work"});
         var eventUrl = common.URL + "/admin/event/" + event.id;
         var addSelector = "tr[data-user-id='" + user.id + "'] .add-event";
-        var removeSelector = "[data-event-id='" + event.id + "'].remove-event";
+        var removeSelector = "[data-event-id='" + event.id + "'][data-user-id='" + user.id + "'].remove-event";
 
         browser.mockAuthenticate("superuser1");
         browser.get(common.URL + "/admin/users/")


### PR DESCRIPTION
There are plenty of times when the user list, or parts of it, would need to
be displayed in a sensible order. This patch adds default sorting of users
by displayName.