### PR TITLE
open event admin page in new window.

### DIFF
--- a/views/event.ejs
+++ b/views/event.ejs
@@ -606,7 +606,7 @@
                     <i class="fa fa-plus-square fa-lg fa-fw"></i>&nbsp;Create Session
                 </a>
                 
-                <a role="menuitem" href="/admin/event/" role="button" id="admin-page-for-event">
+                <a role="menuitem" href="/admin/event/" role="button" id="admin-page-for-event" target="_blank">
                     <i class="fa fa-pencil-square-o fa-lg fa-fw"></i>
                     Edit Event Info
                 </a>


### PR DESCRIPTION
It's quite jarring to click the event admin link while in an event and leave
the event. Opening the admin page in a new window solves this issue.