### PR TITLE
embed event id in underscore template for admin buttons.

### DIFF
--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -205,8 +205,6 @@ $(document).ready(function() {
         maybeMute();
 
         logger.log("Initialized app.");
-
-        $("#admin-page-for-event").attr("href", "/admin/event/" + curEvent.id);
         
         $("#superuser-page-for-followupemail").attr("href", "/followup/event/" 
             + curEvent.id + "/participant_0");

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -605,8 +605,8 @@
                 <a role="menuitem" href="#create-session-modal" data-toggle="modal" id="show-create-session-modal">
                     <i class="fa fa-plus-square fa-lg fa-fw"></i>&nbsp;Create Session
                 </a>
-                
-                <a role="menuitem" href="/admin/event/" role="button" id="admin-page-for-event">
+
+                <a role="menuitem" href="/admin/event/{{= event.id }}" role="button" id="admin-page-for-event" target="_blank">
                     <i class="fa fa-pencil-square-o fa-lg fa-fw"></i>
                     Edit Event Info
                 </a>


### PR DESCRIPTION
The admin buttons are rendered via an underscore template, and the template
is re-rendered when necessary already, with the event data passsed in.
It makes more sense for the edit link to receive the event ID directly in
the template, the current approach can lead to odd race conditions.