### PR TITLE
fix missing destination param for error case.

### DIFF
--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -780,7 +780,8 @@ module.exports = {
                 return res.render('admin-event.ejs', {
                     user: req.user,
                     event: copy,
-                    errors: errors
+                    errors: errors,
+                    destination: req.query.destination || ""
                 });
             }
             if (_.size(copy.changed) > 0) {


### PR DESCRIPTION
The existing destination handling code missed passing a destination param
to the event admin template in the case of a validation error.