### PR TITLE
fix missing exports value for jQuery.hotkeys

### DIFF
--- a/public/js/requirejs-config.json
+++ b/public/js/requirejs-config.json
@@ -24,7 +24,7 @@
     "shim": {
         "jquery": { "exports": "jQuery" },
         "jquery-ui": { "deps": ["jquery"], "exports": "jQuery.fn.ui" },
-        "jquery.hotkeys": { "deps": ["jquery"] },
+        "jquery.hotkeys": { "deps": ["jquery"], "exports": "jQuery.hotkeys" },
         "jquery.validate": { "deps": ["jquery"], "exports": "jQuery.fn.validate" },
         "jquery.autosize": { "deps": ["jquery"], "exports": "jQuery.fn.autosize" },
         "underscore": { "exports": "_" },


### PR DESCRIPTION
The original commit missed adding a valid export of the jQuery.hotkeys
function in the require config.