### PR TITLE
allow CSS styling of event status text.

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -563,6 +563,16 @@ hr.noshade {
   }
 }
 
+#event-status-text {
+  font-weight: bold;
+  &.open {
+    color: #5CB85C;
+  }
+  &.closed {
+    color: #D9524F;
+  }
+}
+
 .event-page-container {
   margin-top: 0px;
   height: 100%;

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -588,12 +588,12 @@
             <li role="presentation">
                 {{ if (event.get("open")) { }}
                     <p role="menuitem">
-                        This event is currently <font color="#5CB85C">OPEN</font>
+                        This event is currently <span id="event-status-text" class="open">OPEN</span>
                         <hr/>
                     </p>                    
                 {{ } else { }}
                     <p role="menuitem">
-                        This event is currently <font color="#D9524F">CLOSED</font>
+                        This event is currently <span id="event-status-text" class="closed">CLOSED</span>
                         <hr/>
                     </p> 
                 {{ } }} 


### PR DESCRIPTION
The current event status text color is hard-coded in a font tag.
This is not design-friendly for sites that wish to, for example,
customize the color of the text. Adjusted to allow greater CSS
customization.