### PR TITLE
ask for Hangouts permissions on login

### DIFF
--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -238,7 +238,14 @@ module.exports = {
         app.get("/auth/google", passport.authenticate('google', {
                 scope: [
                     'https://www.googleapis.com/auth/userinfo.profile',
-                    'https://www.googleapis.com/auth/userinfo.email']
+                    'https://www.googleapis.com/auth/userinfo.email',
+                    // Google Hangouts requires these permissions, by asking
+                    // for them here we reduce friction for first-time users
+                    // joining a hangout.
+                    'https://www.googleapis.com/auth/plus.me',
+                    'https://www.googleapis.com/auth/hangout.av',
+                    'https://www.googleapis.com/auth/hangout.participants',
+                ]
             }),
             function(req, res) {
                 logger.warn("Auth request function called. This is unexpected! We expect this to get routed to google instead.");


### PR DESCRIPTION
according to https://developers.google.com/+/hangouts/running#running-private
google hangouts requires three permissions which are not asked for explicitly
by the unhangout installation. asking for these on the unhangout side will
smooth first-time users' experience of joining a hangout, since the permissions
will have already been granted, and will have no effect on existing platform
users, who have already granted all of these permissions upon logging in and
attending their first breakout session.

tested in my installation, and works perfectly.