### PR TITLE
add request destination handling for identity login button.

### DIFF
--- a/lib/unhangout-routes.js
+++ b/lib/unhangout-routes.js
@@ -233,9 +233,20 @@ module.exports = {
             });
         });
 
+        // Middleware to store a destination path.
+        // If the special _destination query parameter is found, its value
+        // will be stored in the session.
+        var requestPathMiddleware = function(req, res, next) {
+            if (!_.isUndefined(req.query._destination)) {
+               logger.debug("setting login destination", req.query._destination);
+               req.session["post-auth-path"] = req.query._destination;
+            }
+            next();
+        }
+
         // the passport middleware (passport.authenticate) should route this request to
         // google, and not call the rendering callback below.
-        app.get("/auth/google", passport.authenticate('google', {
+        app.get("/auth/google", requestPathMiddleware, passport.authenticate('google', {
                 scope: [
                     'https://www.googleapis.com/auth/userinfo.profile',
                     'https://www.googleapis.com/auth/userinfo.email']

--- a/lib/unhangout-server.js
+++ b/lib/unhangout-server.js
@@ -17,6 +17,7 @@ var logging = require('./logging'),
     RedisStore = require('connect-redis')(express),
     http = require('http'),
     https = require('https'),
+    querystring = require("querystring"),
     nodemailer = require("nodemailer");
     passport = require('passport'),
     GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
@@ -110,6 +111,17 @@ exports.UnhangoutServer.prototype = {
             monotonic: monotonic,
             NODE_ENV: process.env.NODE_ENV
         }
+        // Exposes URL-encoded _destination query parameter.
+        // If it is included in the link to the /auth/google/
+        // path, the user will be redirected to its value.
+        this.app.use(function(req, res, next) {
+            var queryParamString = querystring.stringify(req.query);
+            var queryObj = {
+                _destination: req.path + '?' + queryParamString,
+            }
+            res.locals.requestDestination = querystring.stringify(queryObj);
+            next();
+        });
 
         // Much less repetitive to include these here, both for consistency
         // and because _header.ejs will only have access to these and

--- a/views/_identity.ejs
+++ b/views/_identity.ejs
@@ -1,7 +1,7 @@
 <ul class="navbar-nav nav navbar-right identity">
     <li>
     <% if(!user) {%>
-        <a href="/auth/google" class="login-link"><button class="btn btn-primary login-button">Login</button></a>
+        <a href="/auth/google?<%= requestDestination %>" class="login-link"><button class="btn btn-primary login-button">Login</button></a>
     <% } else { %>
         <div class="dropdown">
             <a class="dropdown-toggle username" data-toggle="dropdown" id='user-menu-label'>


### PR DESCRIPTION
This exposes the requestDestination parameter to all views, which is
a special querystring parameter than can be appended for redirect
destination handling.

The current implementation leverages the existing destination storage
in the user session related to google auth flow. the _destination
parameter is included in the login link in the _identity view, thus
enabling users to be redirected to the same page they were on after
logging in. while ensureAuthenticated() handles the auth-required
case, this handles the anonymous user case.