### PR TITLE
allow event admins with no events to access myevents page.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ module.exports = {
         }
     },
     ensureAdmin: function (req, res, next) {
-        if(req.user.isSuperuser() || req.user.isAdminOfSomeEvent()) {
+        if(req.user.isSuperuser() || req.user.isAdminOfSomeEvent() || req.user.hasPerm("createEvents")) {
             next();
         } else {
             res._errorReason = "Not an admin";

--- a/views/_identity.ejs
+++ b/views/_identity.ejs
@@ -20,7 +20,7 @@
                     <li role="presentation" class="divider"></li>
                 <% } %>
 
-                <% if (user.isSuperuser() || user.isAdminOfSomeEvent()) { %>
+                <% if (user.isSuperuser() || user.isAdminOfSomeEvent() || user.hasPerm("createEvents")) { %>
                     <li role="presentation">
                         <a role="menuitem" tabindex="-1" href="/myevents/">My Events</a>
                     </li>


### PR DESCRIPTION
any user with createEvents permission should be able to access the My Events
page, as they are permissioned to create new events. this patch appropriately
loosens the access permissions for the myevents path, and accompanying display
of the My Events link.