### PR TITLE
restore hangout URLs modal warning.

### DIFF
--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -330,6 +330,7 @@ $(document).ready(function() {
         if(IS_ADMIN) {
             if (NUM_HANGOUT_URLS_WARNING > 0 && NUM_HANGOUT_URLS_AVAILABLE < NUM_HANGOUT_URLS_WARNING) {
                 console.error("Too few hangout URLS available!", NUM_HANGOUT_URLS_AVAILABLE);
+                $("#no-urls-warning").modal('show');
             }
             this.adminButtonView = new eventViews.AdminButtonView({
                 event: curEvent, transport: trans

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -1165,6 +1165,21 @@
             </div>
         </div>
     </div>
+
+    <div class="modal fade" id="no-urls-warning" role="dialog" aria-hidden="true">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>NO HANGOUT URLS AVAILABLE</h3>
+            </div>
+            <div class="modal-body alert alert-danger">
+                    <p>There are currently <strong><%= numHangoutUrlsAvailable %></strong> Hangout urls available on the server. Sessions started when there are no urls available will fall back to the callback method of hangout starting, which requires the first person to join a session to create the hangout. This is not desireable; we strongly recommend you contact a system administrator and ask them to add more farmed URLs to your installation.
+            </div>
+            <div class="modal-footer">
+                <a href="#" class="btn btn-default" id="dismiss-farming-warning" data-dismiss='modal'>Dismiss</a>
+            </div>
+        </div>
+    </div>
+
 </script>
 
 <% include _video-templates.ejs %>


### PR DESCRIPTION
this functionality still works, and is even more useful now that hangout urls
cannot be autofarmed. modal content has been adjusted to account for new
workflow for adding hangout urls to redis.

i did not restore any of the tests related to farming -- only one even applied
to the new workflow. it seems best to write the new ones from the ground up.