### PR TITLE
Redesign of randomized breakouts 

### DIFF
--- a/bin/prepare-load-simulator-data.js
+++ b/bin/prepare-load-simulator-data.js
@@ -102,8 +102,10 @@ function create(callback) {
                         sess.destroy({success: resolve, error: reject});
                     });
                 }))
-                .then(function() { done(null, event); });
+                .then(function() { done(null, event); })
                 .catch(function(err) { done(err, event); });
+            } else {
+              done(null, event);
             }
         },
         // Create new sessions

--- a/lib/random-grouping.js
+++ b/lib/random-grouping.js
@@ -17,9 +17,7 @@ module.exports = function(db, options) {
             var title = "Breakout Room " + roomNum;
             // Force sessions type to be "simple"
             var activities = [{type: "about", autoHide: true}];
-            /* Keep the sessions' joining cap as 6 for now, we'll change this 
-            later and make it as an input available for admins */
-            var joinCap = 6; 
+            var joinCap = event.get("sessionSize"); 
 
             var newSession = new models.ServerSession({
                 title: title,

--- a/lib/unhangout-sockets.js
+++ b/lib/unhangout-sockets.js
@@ -717,7 +717,13 @@ _.extend(UnhangoutSocketManager.prototype, events.EventEmitter.prototype, {
                 value: isOpen
             });
         });
-
+        this.db.events.on("change:sessionSize", function(event, size) {
+            mgr.sync(event.getRoomId(), "state", {
+                path: ["event", "sessionSize"],
+                op: "set",
+                value: size
+            });
+        });
         this.db.events.on("change:adminProposedSessions", function(event, mode) {
             mgr.sync(event.getRoomId(), "state", {
                 path: ["event", "adminProposedSessions"],

--- a/lib/unhangout-sockets.js
+++ b/lib/unhangout-sockets.js
@@ -402,6 +402,7 @@ _.extend(UnhangoutSocketManager.prototype, events.EventEmitter.prototype, {
                     event.save({randomizedSessions: false});
                 } else if (args.mode == "randomized") {
                     event.save({randomizedSessions: true});
+                    event.save({sessionSize: args.size});
                 }
 
                 mgr.writeAck(socket, "proposed-mode");

--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -950,6 +950,7 @@ user-admin-border-size = 2px
   width: 100%;
   min-height: 85px;
   background-color: #eee;
+  margin-bottom: 5px;
 
   .group-area {
     padding: 0px;

--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -941,6 +941,93 @@ user-admin-border-size = 2px
   width: 100%;
 }
 
+/* 
+* Dummy session display on event page
+*/
+.dummy-session {
+  padding: 0px;
+  border-radius: 5px;
+  width: 100%;
+  min-height: 85px;
+  background-color: #eee;
+
+  .group-area {
+    padding: 0px;
+    padding-top: 15px
+  }
+
+  .join-session {
+    padding: 0x;
+    padding-bottom: 15px;
+    padding-left: 10px;
+  }
+
+  .no-padding {
+    padding: 0px;
+  }
+
+  .btn-group-me {
+    padding: 0px;
+    color: #fff;
+    width: 100%;
+    -webkit-border-radius: 2px;
+    border-radius: 2px;
+    font-size: 14px;
+    font-weight: 300;
+    letter-spacing: 0.5px;
+    height: 30px;
+  }
+
+  .session-area {
+    padding: 0px;
+    padding-bottom: 15px;
+  }
+
+  h3 {
+    color: $primary;
+    font-weight: normal;
+    font-size: 1em;
+    padding: 0px;
+    margin: 0px;
+  }
+
+  hr {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    border-top: 1px solid #c0c0c0;
+  }
+
+  .session-spots {
+    padding: 0px;
+  }
+
+  .dummy-group-members {
+    margin-top: 5px;
+    margin-left: 0px;
+    margin-bottom: 10px;
+    padding: 0px;
+    padding-left: 15px;
+  }
+
+  .dummy-hangout-users {
+    margin-top: 5px;
+    margin-left: 0px;
+    margin-bottom: 10px;
+    padding: 0px;
+    padding-left: 0px;
+  }
+
+  .empty {
+    background-color: white;
+    border: 1px solid #dfdfdf;
+    float: left;
+    width: 30px;
+    height: 30px;
+    list-style: none;
+    border-radius: 2px;
+  }
+}
+
 /*
  * Session display on event page
  */

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -176,6 +176,15 @@ $(document).ready(function() {
             $("#btn-group-me").show();
             $("#random-list").show();
             $("#topic-list").hide();
+            if(curEvent.get("sessionsOpen")) {
+                $(".btn-group-me").find(".text").text("JOIN");
+                $(".btn-group-me").find(".lock").hide();
+                $(".btn-group-me").attr("disabled", false);
+            } else {
+                $(".btn-group-me").find(".text").text("LOCKED");
+                $(".btn-group-me").addClass("disabled");
+                $(".btn-group-me").attr("disabled", true);
+            }
         } else {
             $("#random-list").hide();
             $("#btn-group-me").hide();
@@ -192,7 +201,7 @@ $(document).ready(function() {
 
         if(IS_ADMIN) {
             curEvent.on("change:adminProposedSessions change:sessionsOpen change:open", _.bind(function() {
-                this.adminButtonView.render();  
+                this.adminButtonView.render(); 
             }, this));
         }
 

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -173,7 +173,6 @@ $(document).ready(function() {
         if(curEvent.get("randomizedSessions")) {
             $("#btn-propose-session").hide();
             $("#btn-create-session").hide();
-            $("#btn-group-me").show();
             $("#random-list").show();
             $("#topic-list").hide();
             if(curEvent.get("sessionsOpen")) {
@@ -187,7 +186,6 @@ $(document).ready(function() {
             }
         } else {
             $("#random-list").hide();
-            $("#btn-group-me").hide();
             if(!curEvent.get("adminProposedSessions")) {
                 $("#btn-propose-session").show();
                 $("#btn-create-session").hide();
@@ -394,9 +392,9 @@ $(document).ready(function() {
           return sess.get("assignedParticipants").indexOf(auth.USER_ID) !== -1;
         });
         if(thisEventAssign) {
-            $("#btn-group-me").find(".text").text("REGROUP ME");
+            $("#btn-regroup-me").show();
         } else {
-            $("#btn-group-me").find(".text").text("GROUP ME");
+            $("#btn-regroup-me").hide();
         }
     }, app);
 

--- a/public/js/event-app.js
+++ b/public/js/event-app.js
@@ -184,6 +184,7 @@ $(document).ready(function() {
                 $(".btn-group-me").addClass("disabled");
                 $(".btn-group-me").attr("disabled", true);
             }
+            $(".empty-notice").hide();
         } else {
             $("#random-list").hide();
             if(!curEvent.get("adminProposedSessions")) {
@@ -388,13 +389,16 @@ $(document).ready(function() {
         $("#linkedin_url").val(USER.preferredContact.linkedinURL);
         $("#noShareChkBox").prop("checked", USER.preferredContact.noShare);
 
-        var thisEventAssign = curEvent.get("sessions").find(function(sess) {
+        var thisEventAssign  = curEvent.get("sessions").find(function(sess) {
           return sess.get("assignedParticipants").indexOf(auth.USER_ID) !== -1;
         });
+        
         if(thisEventAssign) {
             $("#btn-regroup-me").show();
+            $(".dummy-session").hide();
         } else {
             $("#btn-regroup-me").hide();
+            $(".dummy-session").show();
         }
     }, app);
 

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -59,7 +59,7 @@ views.SessionView = Backbone.Marionette.ItemView.extend({
         this.listenTo(this.model, 'change:connectedParticipants', this.render, this);
         this.listenTo(this.model, 'change:joiningParticipants', this.render, this);
         this.listenTo(this.model, 'change:assignedParticipants', this.render, this);
-        this.listenTo(this.model, 'change:assignedParticipants', this.differentMethod, this); 
+        this.listenTo(this.model, 'change:assignedParticipants', this.openHangoutWindow, this); 
         this.listenTo(this.options.event.get("connectedUsers"), 'add',
                       this.maybeRenderOnAddConnectedUser, this);
         this.listenTo(this.options.event, 'change:adminProposedSessions', this.render, this);
@@ -76,7 +76,7 @@ views.SessionView = Backbone.Marionette.ItemView.extend({
         this.listenTo(this.model, 'change:title', this.render, this);
     },
 
-    differentMethod: function() {
+    openHangoutWindow: function() {
         if(this.options.event.get("randomizedSessions")) {
             if(this.model.get("assignedParticipants").indexOf(USER.id) >= 0) {
                 if(!this.options.event.get("sessionsOpen")) {
@@ -581,7 +581,7 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
     id: "session-list",
 
     events: {
-        'click #btn-group-me': 'groupUser',
+        'click .btn-group-me': 'groupUser',
     },  
 
     initialize: function() {

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -656,16 +656,15 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
         if(this.options.event.get("randomizedSessions")) {
             $("#btn-propose-session").hide();
             $("#btn-create-session").hide();
-            $("#btn-group-me").show();
+            $("#btn-regroup-me").hide();
             var thisEventAssign = this.getMySessionAssignment();
             if(thisEventAssign) {
-                $("#btn-group-me").find(".text").text("REGROUP ME");
-            } else {
-                $("#btn-group-me").find(".text").text("GROUP ME");
-            }
+                $("#btn-regroup-me").find(".text").text("REGROUP ME");
+                $("#btn-regroup-me").show();
+            } 
             this.modifyDummySessionJoinButton();
         } else {
-            $("#btn-group-me").hide();
+            $("#btn-regroup-me").hide();
             if(this.options.event.get("adminProposedSessions")) {
                 $("#btn-propose-session").hide();
                 $("#btn-create-session").show();

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -721,7 +721,8 @@ views.DialogView = Backbone.Marionette.Layout.extend({
         'click #set-iframe-code': 'setIframeCode',
         'click #propose': 'proposeSession', 
         'input .input-topic-title': 'fillTopicPreview',
-        'click #regroup': 'regroupUser'
+        'click #regroup': 'regroupUser',
+        'click #enable-randomized-sessions-mode': 'enableRandomizedSessionsMode'
     },
 
     addUrlToSessionMessage: function(event) {
@@ -735,6 +736,24 @@ views.DialogView = Backbone.Marionette.Layout.extend({
         $("#message-sessions-modal .faux-hangout-notice .message").html(
             _.escape(formatSessionMessage($("#session_message").val()))
         );
+    },
+
+    enableRandomizedSessionsMode: function(jqevt) {
+        jqevt.preventDefault();
+        var el = $("#randomized-sessions-modal input");
+        var val = el.val();
+        
+        if(val > 10) {
+            val = 10; 
+        } else if (val < 0) {
+            val = 0;
+        }
+
+        this.options.transport.send("proposed-mode", {
+            roomId: this.options.event.getRoomId(),
+            size: val,
+            mode: "randomized"
+        });
     },
 
     fillTopicPreview: function(event) {
@@ -1038,7 +1057,7 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
         'mouseover #choose-breakout-mode': 'chooseBreakoutSubmenu',
         'click #admin-proposed-sessions-mode': 'disableParticipantProposedMode',
         'click #participant-proposed-sessions-mode': 'enableParticipantProposedMode',
-        'click #randomized-sessions-mode': 'enableRandomizedSessionsMode'
+        'click #randomized-sessions': "openRandomizedSessionsModal"
     },
 
     openSessions: function(jqevt) {
@@ -1098,9 +1117,9 @@ views.AdminButtonView = Backbone.Marionette.Layout.extend({
         this.changeSessionsProposedMode("participantProposed");
     },
 
-    enableRandomizedSessionsMode: function(jqevt) {
+    openRandomizedSessionsModal: function(jqevt) {
         jqevt.preventDefault();
-        this.changeSessionsProposedMode("randomized"); 
+        $("#randomized-sessions-modal").modal('show');
     },
 
     changeSessionsProposedMode: function(action) {

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -571,6 +571,7 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
 
     events: {
         'click .btn-group-me': 'groupUser',
+        'click #btn-regroup-me': 'groupUser'
     },  
 
     initialize: function() {
@@ -594,9 +595,20 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
     groupUser: function(jqevt) {
         jqevt.preventDefault();
         var thisEventAssign = this.getMySessionAssignment();
+        var mySessionConnected = this.getMySessionConnected();
+
         if(thisEventAssign) {
             var scope = $("#regroup-modal");
             scope.modal('show');
+            if(mySessionConnected) {
+                $(".warning", scope).show();
+                $(".info", scope).hide();
+                $(".regroup", scope).hide();
+            } else {
+                $(".warning", scope).hide();
+                $(".info", scope).show();
+                $(".regroup", scope).show();
+            }
         } else {
             this.options.transport.send("assign-randomized-session", {
                 eventId: this.options.event.id,
@@ -609,6 +621,12 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
         if(this.options.event.get("randomizedSessions")) {
             this.$el.append(this.dummySessionTemplate());
         } 
+    },
+
+    getMySessionConnected: function() {
+        return this.options.event.get("sessions").find(function(sess) {
+            return _.pluck(sess.get("connectedParticipants"), "id").indexOf(auth.USER_ID) !== -1;
+        });
     },
 
     getMySessionAssignment: function() {

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -561,21 +561,10 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
     itemView: views.SessionView,
     itemViewContainer: '#session-list-container',
     breakoutRoomsHeaderTemplate: _.template($("#breakout-rooms-header-template").html()),
-    event: null,
+    dummySessionTemplate: _.template($("#dummy-session-template").html()),
 
     emptyView: Backbone.Marionette.ItemView.extend({
-        initialize: function(options) {
-            event = options.event;
-        },
-
-        template: this.getTemplate,
-        getTemplate: function() {
-            if(event.get("randomizedSessions")) {
-                return "#dummy-session-template"
-            } else {
-                return "#session-list-empty-template"
-            }
-        },        
+        template: "#session-list-empty-template"
     }),
 
     id: "session-list",
@@ -617,6 +606,9 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
 
     renderControls: function() {    
         this.$el.html(this.breakoutRoomsHeaderTemplate());
+        if(this.options.event.get("randomizedSessions")) {
+            this.$el.append(this.dummySessionTemplate());
+        } 
     },
 
     getMySessionAssignment: function() {
@@ -656,15 +648,20 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
         if(this.options.event.get("randomizedSessions")) {
             $("#btn-propose-session").hide();
             $("#btn-create-session").hide();
-            $("#btn-regroup-me").hide();
             var thisEventAssign = this.getMySessionAssignment();
             if(thisEventAssign) {
                 $("#btn-regroup-me").find(".text").text("REGROUP ME");
                 $("#btn-regroup-me").show();
-            } 
+                $(".dummy-session").hide();
+            } else {
+                $("#btn-regroup-me").hide();
+                $(".dummy-session").show();
+            }
             this.modifyDummySessionJoinButton();
+            this.$el.find(".empty-notice").hide();  
         } else {
             $("#btn-regroup-me").hide();
+            $(".dummy-session").hide();
             if(this.options.event.get("adminProposedSessions")) {
                 $("#btn-propose-session").hide();
                 $("#btn-create-session").show();

--- a/public/js/event-views.js
+++ b/public/js/event-views.js
@@ -663,6 +663,7 @@ views.SessionListView = Backbone.Marionette.CollectionView.extend({
             } else {
                 $("#btn-group-me").find(".text").text("GROUP ME");
             }
+            this.modifyDummySessionJoinButton();
         } else {
             $("#btn-group-me").hide();
             if(this.options.event.get("adminProposedSessions")) {

--- a/public/js/models.js
+++ b/public/js/models.js
@@ -100,6 +100,7 @@ models.Event = models.BaseModel.extend({
             open: false,
             connectedUsers: null,
             sessions: null,
+            sessionSize: 10,
             hoa: null,
             youtubeEmbed: null,
             iframeEmbedCode: "",

--- a/test/test.random-grouping.js
+++ b/test/test.random-grouping.js
@@ -15,6 +15,7 @@ describe("RANDOM GROUPING", function() {
     common.standardSetup(function() {
       event = common.server.db.events.get(1);
       event.set("randomizedSessions", true);
+      event.set("sessionSize", 6);
       eventId = event.get("id");
       group = randomGrouping(common.server.db, options);
       done();
@@ -40,7 +41,7 @@ describe("RANDOM GROUPING", function() {
         expect(session.get('title')).to.equal("Breakout Room 1");
         expect(session.get('proposedBy')).to.be.null;
         expect(session.get('activities')).to.deep.equal([{type: "about", autoHide: true}]);
-        expect(session.get('joinCap')).to.equal(6);
+        expect(session.get('joinCap')).to.equal(event.get("sessionSize")); 
         expect(session.get('randomized')).to.equal(true);
         expect(session.get('approved')).to.equal(true);
 

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -290,9 +290,9 @@
 
         <div class="col-lg-6 col-xs-7">
             <a href="#"> 
-                <button class="btn btn-primary" id="btn-group-me">
+                <button class="btn btn-primary" id="btn-regroup-me">
                 <i class="fa fa-random fa-lg fa-lw"></i>
-                <span class="text">GROUP ME</span>
+                <span class="text">REGROUP ME</span>
                 </button>
             </a>   
         </div>

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -1302,7 +1302,8 @@
                 </div>
 
                 <div class="modal-body">
-                    <p> You will lose your spot in your current group
+                    <p class="warning"> It seems like you are already in a Google Hangout window. Close that first, and then try again!</p>
+                    <p class="info"> You will lose your spot in your current group
                     and will not be able to rejoin. </p>
                 </div>
                 <div class="modal-footer">

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -319,7 +319,7 @@
         </div>
         <div class="col-xs-12 session-area">
             <div class="col-xs-9">
-                <h3> Your Breakout Room </h3>
+                <h3> Breakout Room </h3>
                 <div class="col-xs-12 session-spots">
                     <ul class="dummy-hangout-users">
                     <% for(var i=0; i < event.get("sessionSize"); i++) { %>
@@ -1300,9 +1300,8 @@
                 <div class="modal-header">
                     <h4 class="modal-title">Are you sure you want to regroup?</h4>
                 </div>
-
                 <div class="modal-body">
-                    <p class="warning"> It seems like you are already in a Google Hangout window. Close that first, and then try again!</p>
+                    <p class="warning"> It seems like you already have a Google Hangout window open. Close that first, and then try again!</p>
                     <p class="info"> You will lose your spot in your current group
                     and will not be able to rejoin. </p>
                 </div>

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -685,7 +685,7 @@
                 <ul class="dropdown-menu">
                     <li><a href="#" role="button" id="admin-proposed-sessions-mode"><i class='fa fa-user fa-lg fa-fw'></i> Admin Proposed Sessions </a></li>
                     <li><a href="#" role="button" id="participant-proposed-sessions-mode"><i class='fa fa-users fa-lg fa-fw'> </i> Participant Proposed Sessions</a></li>
-                    <li><a href="#" role="button" id="randomized-sessions-mode"><i class="fa fa-random fa-lg fa-fw"></i> Randomized Sessions</a></li>
+                    <li><a href="#" data-toggle="modal" id="randomized-sessions"><i class="fa fa-random fa-lg fa-fw"></i> Randomized Sessions</a></li>
                 </ul>
             </li>
 
@@ -719,26 +719,26 @@
                 <h4 class="modal-title">Create Session</h4>
             </div>
 
-          <div class="modal-body">
+            <div class="modal-body">
             
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for="session_name">Session Name</label>
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for="session_name">Session Name</label>
 
-                <div class="col-lg-9">
-                    <input class="form-control" type="text" name="session_name" value="" id="session_name">
+                    <div class="col-lg-9">
+                        <input class="form-control" type="text" name="session_name" value="" id="session_name">
+                    </div>
                 </div>
-            </div>
 
-            <div class="form-group">
-                <label class="col-lg-3 control-label" for='join_cap'>Participant Limit</label>
+                <div class="form-group">
+                    <label class="col-lg-3 control-label" for='join_cap'>Participant Limit</label>
 
-                <div class="col-lg-4">
-                    <input class="form-control" type='number' min='2' max='10' step='1'
-                       value='10' 
-                       name='join_cap' id='join_cap' />
-                    <span class='help-inline'>Minimum 2, maximum 10</span>
+                    <div class="col-lg-4">
+                        <input class="form-control" type='number' min='2' max='10' step='1'
+                           value='10' 
+                           name='join_cap' id='join_cap' />
+                        <span class='help-inline'>Minimum 2, maximum 10</span>
+                    </div>
                 </div>
-            </div>
 
             <div class="form-group">
                 <div class="col-lg-offset-1 col-lg-10 alert alert-warning alert-dismissible join-cap-error" role="alert">
@@ -1224,6 +1224,34 @@
                     <button type="button" class="btn btn-primary" class="propose" id="propose" data-dismiss="modal">Propose</button>
                 </div>
 
+            </div>
+        </div>
+    </div>
+
+    <div class="modal randomized-sessions-modal" id="randomized-sessions-modal" role="dialog" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">Choose group size and enable randomized sessions mode</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="form-group">
+                            <label class="col-lg-3 control-label" for='join_cap'>Group Size</label>
+
+                            <div class="col-lg-4">
+                                <input class="form-control" type='number' min='2' max='10' step='1'
+                                   value='10' 
+                                   name='join_cap' id='join_cap' />
+                                <span class='help-inline'>Min 2, max 10</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary enable-randomized-sessions-mode" id="enable-randomized-sessions-mode" data-dismiss="modal">Enable Randomized Sessions Mode</button>
+                </div>
             </div>
         </div>
     </div>

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -300,6 +300,45 @@
     <div style='clear: both;'></div>
 </script>
 
+<script type="text/template" id="dummy-session-template">
+    <div class="col-xs-12 dummy-session">
+        <div class="col-xs-12 group-area">
+            <div class="col-xs-12 group-title">
+                <h3> Group Members </h3>
+            </div>
+            <div class="col-xs-12 session-spots">
+                <ul class="dummy-group-members">
+                <% for(var i=0; i < event.get("sessionSize"); i++) { %>
+                    <li class="empty"> </li>
+                <% } %>
+                </ul>
+            </div>
+            <div class="col-xs-12 group-line">
+                <hr/>
+            </div>  
+        </div>
+        <div class="col-xs-12 session-area">
+            <div class="col-xs-9">
+                <h3> Your Breakout Room </h3>
+                <div class="col-xs-12 session-spots">
+                    <ul class="dummy-hangout-users">
+                    <% for(var i=0; i < event.get("sessionSize"); i++) { %>
+                        <li class="empty"> </li>
+                    <% } %>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-xs-3 join-session">
+                <div class="col-lg-12 no-padding">
+                    <button class="btn btn-primary btn-group-me">
+                        <i class="lock fa fa-lock fa-2"></i>&nbsp;<span class="text"> LOCKED</span>
+                    </button>
+                </div>
+            </div>
+        </div> 
+    </div>     
+</script>
+
 <script type="text/template" id="pagination-template">
     <div class="footer">
         <div id="prev">prev</div>
@@ -709,7 +748,6 @@
 </script>
 
 <script type="text/template" id="dialogs-template">
-
     <!-- Create Session Modal Dialog -->
     <div id="create-session-modal" class="create-session-modal modal" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
       <div class="modal-dialog">


### PR DESCRIPTION
Some of the new changes include:
- Ability to input the randomized sessions participant limit through a dialog
- A dummy session UI, which looks exactly like a session, and is shown to a user only if they are not assigned a group yet.
- The JOIN button click on the dummy session assigns a group to a user and opens the Google Hangout window for them.
- Regroup button performs the same function as that of the join button of the dummy UI. In addition, it ensures if the Google Hangout window is not open already for a user. 