### PR TITLE
Fix for user list switching from a three column to a two column list with scrollbars on

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -757,8 +757,8 @@ user-admin-border-size = 2px
   width: user-size
   height: user-size
 
-  margin-top: 5px;
-  margin-left: 5px;
+  margin-top: 4px;
+  margin-left: 4px;
 
   border: user-border-size solid $background;
   box-sizing: border-box;

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -36,7 +36,7 @@
                 <div id="main-left"></div> 
             </div>
 
-            <div class="col-lg-7 col-xs-5 event-column-right">
+            <div class="col-xs-7 event-column-right">
                 <div id="main-right"></div>
             </div> 
 


### PR DESCRIPTION
- Reduced the margin between avatars in the presence gutter by one pixel. User list now remains a three column list when scrollbars show up
- Adjusted the event-right-column bootstrap width. User list now becomes a two column list for screens smaller than col-lg screens.