### PR TITLE
fix error messages display in create/ propose session dialog

### DIFF
--- a/public/css/screen.styl
+++ b/public/css/screen.styl
@@ -2654,9 +2654,8 @@ user-admin-border-size = 2px
 }
 
 #create-session-modal {
-  
-  .session-title-validate-error {
-    margin-top: 10px;
+  .create-session-error {
+    margin: 25px 25px 0px 25px;
   }
 }
 
@@ -2736,9 +2735,9 @@ user-admin-border-size = 2px
     }
   }
 
-  .proposed-title-validate-error {
-    margin: 0px;
+  .propose-session-error {
     margin-top: 15px;
+    margin-bottom: 5px;
   }
 }
 

--- a/test/test.create-sessions.selenium.js
+++ b/test/test.create-sessions.selenium.js
@@ -156,8 +156,8 @@ describe("CREATE SESSIONS", function() {
             expect(val).to.be("");
         });
         browser.byCss("#create-session").click();
-        browser.waitForSelector(".join-cap-error");
-        browser.executeScript("$('.join-cap-error').hide();");
+        browser.waitForSelector(".create-session-error");
+        browser.executeScript("$('.create-session-error').hide();");
 
         // Error for too low
         browser.waitForSelector("#session_name");
@@ -165,8 +165,8 @@ describe("CREATE SESSIONS", function() {
         browser.byCss("#join_cap").clear();
         browser.byCss("#join_cap").sendKeys("1");
         browser.byCss("#create-session").click();
-        browser.waitForSelector(".join-cap-error");
-        browser.executeScript("$('.join-cap-error').hide();");
+        browser.waitForSelector(".create-session-error");
+        browser.executeScript("$('.create-session-error').hide();");
 
         // Error for too high
         browser.waitForSelector("#session_name");
@@ -174,16 +174,17 @@ describe("CREATE SESSIONS", function() {
         browser.byCss("#join_cap").clear();
         browser.byCss("#join_cap").sendKeys("11");
         browser.byCss("#create-session").click();
-        browser.waitForSelector(".join-cap-error");
-        browser.executeScript("$('.join-cap-error').hide();");
+        browser.waitForSelector(".create-session-error");
+        browser.executeScript("$('.create-session-error').hide();");
 
         // Goldilocks
 
         browser.waitForSelector("#session_name");
         browser.byCss("#session_name").sendKeys("Joining Capacity");
         browser.byCss("#join_cap").clear();
+        browser.executeScript("$('#join_cap').val('');");
         browser.byCss("#join_cap").sendKeys("3");
-        browser.byCss("#create-session").click();
+        browser.byCss("#create-session").click();   
 
         browser.waitForSelector(".session .hangout-users");
         browser.byCsss(".session .hangout-users li").then(function(els) {

--- a/views/event.ejs
+++ b/views/event.ejs
@@ -271,21 +271,17 @@
         </div>
 
         <div class="col-lg-6 col-xs-7">
-            <a href="#propose-session-modal" data-toggle="modal"> 
-                <button class="btn btn-primary" id="btn-propose-session">
-                <i class="fa fa-plus fa-lg fa-lw"></i>
-                PROPOSE A SESSION
-                </button>
-            </a>   
+            <button class="btn btn-primary" id="btn-propose-session">
+            <i class="fa fa-plus fa-lg fa-lw"></i>
+            PROPOSE A SESSION
+            </button>
         </div>
 
         <div class="col-lg-6 col-xs-7">
-            <a href="#create-session-modal" data-toggle="modal"> 
-                <button class="btn btn-primary" id="btn-create-session">
-                <i class="fa fa-plus fa-lg fa-lw"></i>
-                CREATE A SESSION
-                </button>
-            </a>   
+            <button class="btn btn-primary" id="btn-create-session">
+            <i class="fa fa-plus fa-lg fa-lw"></i>
+            CREATE A SESSION
+            </button>
         </div>
 
         <div class="col-lg-6 col-xs-7">
@@ -696,11 +692,8 @@
         //Hide the youtube and webpage url form controls
         $(".youtube-url").hide();
         $(".webpage-url").hide();
-        $(".join-cap-error").hide();
         $('[data-toggle="tooltip"]').tooltip();
-        
     </script>
-
 </script>
 
 <script type="text/template" id="session-live-bar-template">
@@ -741,14 +734,6 @@
             </div>
 
             <div class="form-group">
-                <div class="col-lg-offset-1 col-lg-10 alert alert-warning alert-dismissible join-cap-error" role="alert">
-                  <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                  Warning! Please enter a number between 2 and 10.
-                </div>
-            </div>
-
-             <div class="form-group">
-                     
                 <label class="col-lg-3 control-label">
                     Session Type
                 </label>
@@ -767,48 +752,29 @@
                     </label>
                     
                     <div class='form-group youtube-url'>
-                        <p class="yt-error hide">
-                            Unrecognized youtube URL.  Please use the URL for a single video.
-                        </p>
-
                         <label class="col-lg-4 control-label" for="session_youtube_id">Youtube URL</label>
                         
                         <div class="col-lg-8">
-
                             <input class="form-control" type="text" name="youtube_id" value=""
                                    id="session_youtube_id"
                                    placeholder='https://youtube.com'>
-
                             <span class='help-block'>Paste the URL or embed code for a youtube video.</span>
-
                         </div>
                     </div>
 
                     <div class='form-group webpage-url'>
                         <label class="col-lg-4 control-label" for='session_webpage'>Webpage URL</label>
-
                         <div class="col-lg-8">
-
                             <input class="form-control" type='text' placeholder='https://example.com' id='session_webpage'/>
-
-                            <div class='url-error hide' style='display: none;'>
-                                Sorry, but only secure pages (those starting with "https")
-                                can be embedded in hangouts.
-                            </div>
                         </div>
-
                     </div>
-
-                    <div class="col-lg-12 alert alert-danger alert-dismissible session-title-validate-error validate-error hide" role="alert">
-
-                        <button type="button" class="close" data-dismiss="alert"><span class="sr-only">Close</span></button>
-                    Title should be less than 80 characters
-
-                    </div>
-
+                </div>
+                
+                <div class="col-lg-11 alert alert-danger alert-dismissible create-session-error hide" role="alert">
+                    <button type="button" class="close" data-dismiss="alert"><span class="sr-only">Close</span></button>
+                Title should be less than 80 characters
                 </div>
             </div>
-
           </div> 
 
           <div class="modal-footer">
@@ -1174,48 +1140,43 @@
                         </div>
 
                         <div class="session-preview col-xs-12">
+                            <div class="col-xs-12 proposed-session-box">
+                                <div class="col-lg-8 col-xs-7 no-padding">
 
-                        <div class="col-xs-12 proposed-session-box">
-                            <div class="col-lg-8 col-xs-7 no-padding">
+                                    <p class="title-preview">Your title will appear here</p>
+                                  
+                                </div>
 
-                                <p class="title-preview">Your title will appear here</p>
-                              
-                            </div>
-
-                            <div class="col-lg-4 col-xs-5 left-padding">
-                                <div class="col-xs-12 no-padding">
-            
-                                    <div class="col-lg-3 col-xs-4 no-padding">
-                                        <img src="<%= user.get("picture")%>" id="participantPic"> 
-                                    </div>
-
-                                    <div class="proposee-display-name col-lg-9 col-xs-8 no-padding">      
-                                        <%= user.get("displayName")%>
-                                    </div>       
-                            
-
+                                <div class="col-lg-4 col-xs-5 left-padding">
                                     <div class="col-xs-12 no-padding">
-                                        <button class="btn btn-primary btn-vote" disabled=" ">
-                                            VOTE | 1 
-                                            </button>
+                
+                                        <div class="col-lg-3 col-xs-4 no-padding">
+                                            <img src="<%= user.get("picture")%>" id="participantPic"> 
+                                        </div>
+
+                                        <div class="proposee-display-name col-lg-9 col-xs-8 no-padding">      
+                                            <%= user.get("displayName")%>
+                                        </div>       
+                                
+
+                                        <div class="col-xs-12 no-padding">
+                                            <button class="btn btn-primary btn-vote" disabled=" ">
+                                                VOTE | 1 
+                                                </button>
+                                        </div>
+
                                     </div>
 
                                 </div>
 
                             </div>
-
-                        </div>
                         </div>  
 
-                        <div class="col-lg-12 alert alert-danger alert-dismissible proposed-title-validate-error validate-error hide" role="alert">
-
+                        <div class="col-lg-12 alert alert-danger alert-dismissible propose-session-error hide" role="alert">
                             <button type="button" class="close" data-dismiss="alert"><span class="sr-only">Close</span></button>
                             Title should be less than 80 characters
-
                         </div>
-
                     </div>
-
                 </div>
 
                 <div class="modal-footer">


### PR DESCRIPTION
- removes div elements for individual errors, instead uses one div block for error messages in create/ propose session dialog
- hides error messages when a dialog is invoked
- fixes the bug with error messages not shown and session not created in case of an invalid URL entered in 'Webpage' and 'Youtube' session type 